### PR TITLE
suites/fs/basic: add mds_creation_retry

### DIFF
--- a/suites/fs/basic/tasks/mds_creation_retry.yaml
+++ b/suites/fs/basic/tasks/mds_creation_retry.yaml
@@ -1,0 +1,7 @@
+tasks:
+-mds_creation_failure:
+-ceph-fuse:
+- workunit:
+    clients:
+      all: [misc/trivial_sync.sh]
+


### PR DESCRIPTION
This invokes the new mds_creation_failure task from
teuthology, ahead of mounting the FS and running the
trivial_sync workload.  It is a regression test
for #7485.

Fixes: #7485

Signed-off-by: John Spray john.spray@inktank.com
