### PR TITLE
Fix parallel workunit issues.

### DIFF
--- a/suites/upgrade/dumpling-x/parallel/1-dumpling-install/dumpling.yaml
+++ b/suites/upgrade/dumpling-x/parallel/1-dumpling-install/dumpling.yaml
@@ -2,8 +2,7 @@ tasks:
 - install:
     branch: dumpling
 - ceph:
-   fs: xfs
+    fs: xfs
 - parallel:
-   - workload
-   - upgrade-sequence
-   - final-workload
+    - workload
+    - upgrade-sequence

--- a/suites/upgrade/dumpling-x/parallel/2-workload/rados_api.yaml
+++ b/suites/upgrade/dumpling-x/parallel/2-workload/rados_api.yaml
@@ -1,8 +1,8 @@
 workload:
-   sequential:
-     - workunit:
-       branch: dumpling
-       clients:
+  sequential:
+    - workunit:
+        branch: dumpling
+        clients:
           client.0:
             - rados/test-upgrade-firefly.sh
             - cls

--- a/suites/upgrade/dumpling-x/parallel/2-workload/rados_loadgenbig.yaml
+++ b/suites/upgrade/dumpling-x/parallel/2-workload/rados_loadgenbig.yaml
@@ -1,7 +1,7 @@
 workload:
-   sequential:
-    -  workunit:
-       branch: dumpling
-       clients:
+  sequential:
+    - workunit:
+        branch: dumpling
+        clients:
           client.0:
-             - rados/load-gen-big.sh
+            - rados/load-gen-big.sh

--- a/suites/upgrade/dumpling-x/parallel/2-workload/test_rbd_api.yaml
+++ b/suites/upgrade/dumpling-x/parallel/2-workload/test_rbd_api.yaml
@@ -1,7 +1,7 @@
 workload:
   sequential:
     - workunit:
-      branch: dumpling
-      clients:
-        client.0:
-           - rbd/test_librbd.sh
+        branch: dumpling
+        clients:
+          client.0:
+            - rbd/test_librbd.sh

--- a/suites/upgrade/dumpling-x/parallel/2-workload/test_rbd_python.yaml
+++ b/suites/upgrade/dumpling-x/parallel/2-workload/test_rbd_python.yaml
@@ -1,7 +1,7 @@
 workload:
   sequential:
     - workunit:
-      branch: dumpling
-      clients:
-        client.0:
-           - rbd/test_librbd_python.sh
+        branch: dumpling
+        clients:
+          client.0:
+            - rbd/test_librbd_python.sh

--- a/suites/upgrade/dumpling-x/parallel/4-final-workload/rados-snaps-few-objects.yaml
+++ b/suites/upgrade/dumpling-x/parallel/4-final-workload/rados-snaps-few-objects.yaml
@@ -1,6 +1,6 @@
 final-workload:
-    - rados:
-        clients: [client.1]
+  - rados:
+      clients: [client.1]
         ops: 4000
         objects: 50
         op_weights:

--- a/suites/upgrade/dumpling-x/parallel/4-final-workload/rados_loadgenmix.yaml
+++ b/suites/upgrade/dumpling-x/parallel/4-final-workload/rados_loadgenmix.yaml
@@ -1,5 +1,5 @@
 final-workload:
-   - workunit:
-     clients:
-       client.1:
-         - rados/load-gen-mix.sh
+  - workunit:
+      clients:
+        client.1:
+          - rados/load-gen-mix.sh

--- a/suites/upgrade/dumpling-x/parallel/4-final-workload/rbd_cls.yaml
+++ b/suites/upgrade/dumpling-x/parallel/4-final-workload/rbd_cls.yaml
@@ -1,6 +1,6 @@
 final-workunit:
-    - workunit:
-        clients:
-          client.1:
-            - cls/test_cls_rbd.sh
+  - workunit:
+      clients:
+        client.1:
+          - cls/test_cls_rbd.sh
 

--- a/suites/upgrade/dumpling-x/parallel/4-final-workload/rbd_import_export.yaml
+++ b/suites/upgrade/dumpling-x/parallel/4-final-workload/rbd_import_export.yaml
@@ -1,7 +1,7 @@
 final-workload:
-    - workunit:
-    clients:
+  - workunit:
+      clients:
         client.1:
           - rbd/import_export.sh
-    env:
+      env:
         RBD_CREATE_ARGS: --new-format

--- a/suites/upgrade/dumpling-x/parallel/4-final-workload/rgw_s3tests.yaml
+++ b/suites/upgrade/dumpling-x/parallel/4-final-workload/rgw_s3tests.yaml
@@ -1,5 +1,5 @@
 final-workload:
-    - rgw: [client.1]
+  - rgw: [client.1]
     - s3tests:
         client.1:
           rgw_server: client.1

--- a/suites/upgrade/dumpling-x/parallel/4-final-workload/rgw_swift.yaml
+++ b/suites/upgrade/dumpling-x/parallel/4-final-workload/rgw_swift.yaml
@@ -1,5 +1,5 @@
 final-workload:
-    - rgw: [client.1]
-    - swift:
-        client.1:
-          rgw_server: client.1
+  - rgw: [client.1]
+  - swift:
+      client.1:
+        rgw_server: client.1


### PR DESCRIPTION
Fixed the spacing of workunits inside 2-workload and 4-final-workland
files.  Removed parallel final-workload reference from dumpling.yaml.

Fixes: 7633
Signed-off-by: Warren Usui warren.usui@inktank.com
