### PR TITLE
krbd, kcephfs: trash osd primary-affinity

### DIFF
--- a/suites/kcephfs/thrash/thrashers/default.yaml
+++ b/suites/kcephfs/thrash/thrashers/default.yaml
@@ -5,4 +5,3 @@ tasks:
     - wrongly marked me down
     - objects unfound and apparently lost
 - thrashosds:
-    thrash_primary_affinity: false

--- a/suites/krbd/thrash/thrashers/default.yaml
+++ b/suites/krbd/thrash/thrashers/default.yaml
@@ -5,4 +5,3 @@ tasks:
     - wrongly marked me down
     - objects unfound and apparently lost
 - thrashosds:
-    thrash_primary_affinity: false


### PR DESCRIPTION
libceph.ko support is in testing and should be in 3.15.  This commit
effectively reverts commit 66ffaa65657b ("kcephfs, krbd: do not thrash
primary-affinity").

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
