### PR TITLE
FIxed dumpling - emperor upgrade suites

### DIFF
--- a/suites/upgrade/dumpling-emperor-x/parallel/2-workload/rados_api.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/2-workload/rados_api.yaml
@@ -1,9 +1,8 @@
 workload:
    sequential:
-     - workunit:
+   - workunit:
        branch: dumpling
        clients:
-          client.0:
-            - rados/test.sh
-            - cls
-
+         client.0:
+         - rados/test.sh
+         - cls

--- a/suites/upgrade/dumpling-emperor-x/parallel/2-workload/rados_loadgenbig.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/2-workload/rados_loadgenbig.yaml
@@ -1,7 +1,7 @@
 workload:
    sequential:
-    -  workunit:
+   - workunit:
        branch: dumpling
        clients:
-          client.0:
-             - rados/load-gen-big.sh
+         client.0:
+         - rados/load-gen-big.sh

--- a/suites/upgrade/dumpling-emperor-x/parallel/2-workload/test_rbd_api.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/2-workload/test_rbd_api.yaml
@@ -1,7 +1,7 @@
 workload:
   sequential:
-    - workunit:
+  - workunit:
       branch: dumpling
       clients:
         client.0:
-           - rbd/test_librbd.sh
+        - rbd/test_librbd.sh

--- a/suites/upgrade/dumpling-emperor-x/parallel/2-workload/test_rbd_python.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/2-workload/test_rbd_python.yaml
@@ -1,7 +1,7 @@
 workload:
   sequential:
-    - workunit:
+  - workunit:
       branch: dumpling
       clients:
         client.0:
-           - rbd/test_librbd_python.sh
+        - rbd/test_librbd_python.sh

--- a/suites/upgrade/dumpling-emperor-x/parallel/3-emperor-upgrade/emperor.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/3-emperor-upgrade/emperor.yaml
@@ -1,9 +1,10 @@
 tasks:
-- install.upgrade:
-   branch: emperor
-- ceph:
-   fs: xfs
-- ceph.restart:
-- parallel:
-   - workload
-   - upgrade-sequence
+   - install.upgrade:
+       mon.a:
+         branch: emperor
+       mon.b:
+         branch: emperor
+   - ceph.restart:
+   - parallel:
+     - workload2
+     - upgrade-sequence

--- a/suites/upgrade/dumpling-emperor-x/parallel/4-workload/rados_api.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/4-workload/rados_api.yaml
@@ -1,9 +1,8 @@
-workload:
-   sequential:
-     - workunit:
-       branch: dumpling
-       clients:
-          client.0:
-            - rados/test.sh
-            - cls
-
+workload2:
+  sequential:
+  - workunit:
+      branch: dumpling
+      clients:
+        client.0:
+        - rados/test.sh
+        - cls

--- a/suites/upgrade/dumpling-emperor-x/parallel/4-workload/rados_loadgenbig.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/4-workload/rados_loadgenbig.yaml
@@ -1,7 +1,7 @@
-workload:
-   sequential:
-    -  workunit:
-       branch: dumpling
-       clients:
-          client.0:
-             - rados/load-gen-big.sh
+workload2:
+  sequential:
+  - workunit:
+      branch: dumpling
+      clients:
+        client.0:
+        - rados/load-gen-big.sh

--- a/suites/upgrade/dumpling-emperor-x/parallel/4-workload/test_rbd_api.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/4-workload/test_rbd_api.yaml
@@ -1,7 +1,7 @@
-workload:
+workload2:
   sequential:
-    - workunit:
+  - workunit:
       branch: dumpling
       clients:
         client.0:
-           - rbd/test_librbd.sh
+        - rbd/test_librbd.sh

--- a/suites/upgrade/dumpling-emperor-x/parallel/4-workload/test_rbd_python.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/4-workload/test_rbd_python.yaml
@@ -1,7 +1,7 @@
-workload:
+workload2:
   sequential:
-    - workunit:
+  - workunit:
       branch: dumpling
       clients:
         client.0:
-           - rbd/test_librbd_python.sh
+        - rbd/test_librbd_python.sh

--- a/suites/upgrade/dumpling-emperor-x/parallel/5-upgrade-sequence/upgrade-all.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/5-upgrade-sequence/upgrade-all.yaml
@@ -1,4 +1,8 @@
 upgrade-sequence:
    sequential:
    - install.upgrade:
+       mon.a:
+         branch: emperor
+       mon.b:
+         branch: emperor
    - ceph.restart: [mon.a, mon.b, mon.c, mds.a, osd.0, osd.1, osd.2, osd.3]

--- a/suites/upgrade/dumpling-emperor-x/parallel/5-upgrade-sequence/upgrade-mds-mon-osd.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/5-upgrade-sequence/upgrade-mds-mon-osd.yaml
@@ -1,7 +1,10 @@
 upgrade-sequence:
    sequential:
    - install.upgrade:
-      all:
+      mon.a:
+        branch: emperor
+      mon.b:
+        branch: emperor
    - ceph.restart: [mds.a]
    - sleep:
        duration: 60

--- a/suites/upgrade/dumpling-emperor-x/parallel/5-upgrade-sequence/upgrade-mon-osd-mds.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/5-upgrade-sequence/upgrade-mon-osd-mds.yaml
@@ -1,7 +1,10 @@
 upgrade-sequence:
    sequential:
    - install.upgrade:
-      all:
+      mon.a:
+        branch: emperor
+      mon.b:
+        branch: emperor
    - ceph.restart:
        daemons: [mon.a]
        wait-for-healthy: false

--- a/suites/upgrade/dumpling-emperor-x/parallel/5-upgrade-sequence/upgrade-osd-mon-mds.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/5-upgrade-sequence/upgrade-osd-mon-mds.yaml
@@ -1,7 +1,10 @@
 upgrade-sequence:
    sequential:
    - install.upgrade:
-      all:
+      mon.a:
+        branch: emperor
+      mon.b:
+        branch: emperor
    - ceph.restart: [osd.0]
    - sleep:
        duration: 60

--- a/suites/upgrade/dumpling-emperor-x/parallel/6-final-workload/rados_loadgenmix.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/6-final-workload/rados_loadgenmix.yaml
@@ -1,5 +1,6 @@
 tasks:
-- workunit:
-   clients:
-     client.1:
-       - rados/load-gen-mix.sh
+  - workunit:
+      branch: dumpling
+      clients:
+        client.1:
+        - rados/load-gen-mix.sh

--- a/suites/upgrade/dumpling-emperor-x/parallel/6-final-workload/rados_mon_thrash.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/6-final-workload/rados_mon_thrash.yaml
@@ -3,6 +3,7 @@ tasks:
     revive_delay: 20
     thrash_delay: 1
 - workunit:
+    branch: dumpling
     clients:
       client.1:
-        - rados/test.sh
+      - rados/test.sh

--- a/suites/upgrade/dumpling-emperor-x/parallel/6-final-workload/rbd_cls.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/6-final-workload/rbd_cls.yaml
@@ -1,6 +1,7 @@
 tasks:
 - workunit:
+    branch: dumpling
     clients:
       client.1:
-        - cls/test_cls_rbd.sh
+      - cls/test_cls_rbd.sh
 

--- a/suites/upgrade/dumpling-emperor-x/parallel/6-final-workload/rbd_import_export.yaml
+++ b/suites/upgrade/dumpling-emperor-x/parallel/6-final-workload/rbd_import_export.yaml
@@ -1,7 +1,8 @@
 tasks:
 - workunit:
+     branch: dumpling
      clients:
         client.1:
-           - rbd/import_export.sh
+        - rbd/import_export.sh
      env:
         RBD_CREATE_ARGS: --new-format


### PR DESCRIPTION
Reformatted many of the yaml files.
Fixed duplication of workunit definitions.
Do not do install.upgrade on clients.
Included branch: definition in final workload files.

Signed-off-by: Warren Usui warren.usui@inktank.com
