### PR TITLE
marginal/multimds: fuse_default_permissions = 0 for ceph-fuse

### DIFF
--- a/suites/marginal/multimds/mounts/ceph-fuse.yaml
+++ b/suites/marginal/multimds/mounts/ceph-fuse.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        fuse_default_permissions: 0
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
This can reduce the test time becuase it avoids sending getattr
request whenever the kernel checks inode permission.

Signed-off-by: Yan, Zheng zheng.z.yan@intel.com
