### PR TITLE
rados/thrash: Add pool_snaps variants

### DIFF
--- a/suites/rados/thrash/workloads/cache-pool-snaps.yaml
+++ b/suites/rados/thrash/workloads/cache-pool-snaps.yaml
@@ -1,0 +1,33 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - must scrub before tier agent can activate
+tasks:
+- exec:
+    client.0:
+      - ceph osd pool create base 4
+      - ceph osd pool create cache 4
+      - ceph osd tier add base cache
+      - ceph osd tier cache-mode cache writeback
+      - ceph osd tier set-overlay base cache
+      - ceph osd pool set cache hit_set_type bloom
+      - ceph osd pool set cache hit_set_count 8
+      - ceph osd pool set cache hit_set_period 3600
+      - ceph osd pool set cache target_max_objects 250
+- rados:
+    clients: [client.0]
+    pools: [base]
+    ops: 4000
+    objects: 500
+    pool_snaps: true
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      copy_from: 50
+      flush: 50
+      try_flush: 50
+      evict: 50
+      snap_create: 50
+      snap_remove: 50
+      rollback: 50

--- a/suites/rados/thrash/workloads/pool-snaps-few-objects.yaml
+++ b/suites/rados/thrash/workloads/pool-snaps-few-objects.yaml
@@ -1,0 +1,14 @@
+tasks:
+- rados:
+    clients: [client.0]
+    ops: 4000
+    objects: 50
+    pool_snaps: true
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      snap_create: 50
+      snap_remove: 50
+      rollback: 50
+      copy_from: 50


### PR DESCRIPTION
I scheduled a rados:thrash suite which had failures that were infrastructure related. This change seems to work based on the tests that did pass.
