### PR TITLE
Added dumpling v0.67.9 version, removed older versions v0.67.2, v0.67.4,...

### DIFF
--- a/suites/upgrade/dumpling/fs/1-dumpling-install/v0.67.2.yaml
+++ b/suites/upgrade/dumpling/fs/1-dumpling-install/v0.67.2.yaml
@@ -1,7 +1,0 @@
-tasks:
-- install:
-    tag: v0.67.2
-- ceph:
-- parallel:
-   - workload
-   - upgrade-sequence

--- a/suites/upgrade/dumpling/fs/1-dumpling-install/v0.67.8.yaml
+++ b/suites/upgrade/dumpling/fs/1-dumpling-install/v0.67.8.yaml
@@ -1,7 +1,0 @@
-tasks:
-- install:
-    tag: v0.67.8
-- ceph:
-- parallel:
-   - workload
-   - upgrade-sequence

--- a/suites/upgrade/dumpling/fs/1-dumpling-install/v0.67.9.yaml
+++ b/suites/upgrade/dumpling/fs/1-dumpling-install/v0.67.9.yaml
@@ -1,6 +1,6 @@
 tasks:
 - install:
-    tag: v0.67.4
+    tag: v0.67.9
 - ceph:
 - parallel:
    - workload

--- a/suites/upgrade/dumpling/rados/1-dumpling-install/v0.67.2.yaml
+++ b/suites/upgrade/dumpling/rados/1-dumpling-install/v0.67.2.yaml
@@ -1,7 +1,0 @@
-tasks:
-- install:
-    tag: v0.67.2
-- ceph:
-- parallel:
-   - workload
-   - upgrade-sequence

--- a/suites/upgrade/dumpling/rados/1-dumpling-install/v0.67.8.yaml
+++ b/suites/upgrade/dumpling/rados/1-dumpling-install/v0.67.8.yaml
@@ -1,7 +1,0 @@
-tasks:
-- install:
-    tag: v0.67.8
-- ceph:
-- parallel:
-   - workload
-   - upgrade-sequence

--- a/suites/upgrade/dumpling/rados/1-dumpling-install/v0.67.9.yaml
+++ b/suites/upgrade/dumpling/rados/1-dumpling-install/v0.67.9.yaml
@@ -1,6 +1,6 @@
 tasks:
 - install:
-    tag: v0.67.4
+    tag: v0.67.9
 - ceph:
 - parallel:
    - workload

--- a/suites/upgrade/dumpling/rbd/1-dumpling-install/v0.67.2.yaml
+++ b/suites/upgrade/dumpling/rbd/1-dumpling-install/v0.67.2.yaml
@@ -1,7 +1,0 @@
-tasks:
-- install:
-    tag: v0.67.2
-- ceph:
-- parallel:
-   - workload
-   - upgrade-sequence

--- a/suites/upgrade/dumpling/rbd/1-dumpling-install/v0.67.8.yaml
+++ b/suites/upgrade/dumpling/rbd/1-dumpling-install/v0.67.8.yaml
@@ -1,7 +1,0 @@
-tasks:
-- install:
-    tag: v0.67.8
-- ceph:
-- parallel:
-   - workload
-   - upgrade-sequence

--- a/suites/upgrade/dumpling/rbd/1-dumpling-install/v0.67.9.yaml
+++ b/suites/upgrade/dumpling/rbd/1-dumpling-install/v0.67.9.yaml
@@ -1,6 +1,6 @@
 tasks:
 - install:
-    tag: v0.67.4
+    tag: v0.67.9
 - ceph:
 - parallel:
    - workload

--- a/suites/upgrade/dumpling/rgw/1-dumpling-install/v0.67.2.yaml
+++ b/suites/upgrade/dumpling/rgw/1-dumpling-install/v0.67.2.yaml
@@ -1,7 +1,0 @@
-tasks:
-- install:
-    tag: v0.67.2
-- ceph:
-- parallel:
-   - workload
-   - upgrade-sequence

--- a/suites/upgrade/dumpling/rgw/1-dumpling-install/v0.67.8.yaml
+++ b/suites/upgrade/dumpling/rgw/1-dumpling-install/v0.67.8.yaml
@@ -1,7 +1,0 @@
-tasks:
-- install:
-    tag: v0.67.8
-- ceph:
-- parallel:
-   - workload
-   - upgrade-sequence

--- a/suites/upgrade/dumpling/rgw/1-dumpling-install/v0.67.9.yaml
+++ b/suites/upgrade/dumpling/rgw/1-dumpling-install/v0.67.9.yaml
@@ -1,6 +1,6 @@
 tasks:
 - install:
-    tag: v0.67.4
+    tag: v0.67.9
 - ceph:
 - parallel:
    - workload


### PR DESCRIPTION
@tmuthamizhan @wusui 
@jdurgin 

Please review and merge.

Added dumpling v0.67.9 version, removed older versions v0.67.2, v0.67.4, v0.67.8

This will reduce number of tests to run, some  tests may failed on old versions, see http://tracker.ceph.com/issues/8409

Signed-off-by: Yuri Weinstein yuri.weinstein@inktank.com
