### PR TITLE
krbd: add librbd_fsx -K job

### DIFF
--- a/suites/krbd/rbd-nomount/tasks/rbd_kfsx.yaml
+++ b/suites/krbd/rbd-nomount/tasks/rbd_kfsx.yaml
@@ -1,0 +1,10 @@
+tasks:
+- rbd_fsx:
+    clients: [client.0]
+    ops: 5000
+    krbd: true
+    readbdy: 512
+    writebdy: 512
+    truncbdy: 512
+    punch_holes: false
+    randomized_striping: false


### PR DESCRIPTION
Our fsx fork has recently gained a support for the krbd mode - add it
to the test suite.  Disable discard ops and randomized striping, both
of which aren't ready yet.

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
