### PR TITLE
rados/thrash: set osd_max_backfill = 1 sometimes

### DIFF
--- a/suites/rados/thrash/thrashers/default.yaml
+++ b/suites/rados/thrash/thrashers/default.yaml
@@ -7,6 +7,7 @@ tasks:
     conf:
       osd:
         osd debug reject backfill probability: .3
+        osd max backfills: 1
 - thrashosds:
     timeout: 1200
     chance_pgnum_grow: 1

--- a/suites/rados/thrash/thrashers/morepggrow.yaml
+++ b/suites/rados/thrash/thrashers/morepggrow.yaml
@@ -1,6 +1,9 @@
 tasks:
 - install:
 - ceph:
+    conf:
+      osd:
+        osd max backfills: 1
     log-whitelist:
     - wrongly marked me down
     - objects unfound and apparently lost


### PR DESCRIPTION
Hopefully this will help catch leaks in the recovery reservations.

Signed-off-by: Sage Weil sage@inktank.com
