### PR TITLE
mplement ceph.created_pool

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -1038,6 +1038,17 @@ def wait_for_mon_quorum(ctx, config):
         time.sleep(1)
 
 
+def created_pool(ctx, config):
+    """
+    Add new pools to the dictionary of pools that the ceph-manager
+    knows about.
+    """
+    for new_pool in config:
+        if new_pool not in ctx.manager.pools:
+            ctx.manager.pools[new_pool] = ctx.manager.get_pool_property(
+                                          new_pool, 'pg_num')
+ 
+
 @contextlib.contextmanager
 def restart(ctx, config):
     """


### PR DESCRIPTION
ceph.created_pool allows the user (via yaml lines) to add pools
that the ceph_manager knows about.

Fixes: 9091
Signed-off-by: Warren Usui warren.usui@inktank.com
