### PR TITLE
Moved mon.c to teh first host with mon.a and mon.b to address the issue ...

### DIFF
--- a/suites/upgrade/dumpling-x/stress-split/0-cluster/start.yaml
+++ b/suites/upgrade/dumpling-x/stress-split/0-cluster/start.yaml
@@ -10,8 +10,8 @@ roles:
   - osd.0
   - osd.1
   - osd.2
+  - mon.c
 - - osd.3
   - osd.4
   - osd.5
-  - mon.c
 - - client.0


### PR DESCRIPTION
...Sage found

"... supposed to have half dumpling, half x osds.  but the steps that upgrade and restart the mons upgrade the packages on the second host (which should remain dumpling w/ osd 3,4,5)"

@liewegas Pls review
@dachary 

Signed-off-by: Yuri Weinstein yuri.weinstein@inktank.com
