### PR TITLE
Moved mon.c to the first host with mon.a and mon.b to address the issue

### DIFF
--- a/suites/upgrade/firefly-x/stress-split/0-cluster/start.yaml
+++ b/suites/upgrade/firefly-x/stress-split/0-cluster/start.yaml
@@ -1,6 +1,7 @@
 roles:
 - - mon.a
   - mon.b
+  - mon.c
   - mds.a
   - osd.0
   - osd.1
@@ -8,5 +9,4 @@ roles:
 - - osd.3
   - osd.4
   - osd.5
-  - mon.c
 - - client.0


### PR DESCRIPTION
Sage found:
"... supposed to have half dumpling, half x osds. but the steps that upgrade and restart the mons upgrade the packages on the second host (which should remain dumpling w/ osd 3,4,5)"

Signed-off-by: Yuri Weinstein yuri.weinstein@inktank.com
