### PR TITLE
Use same upgrade-test as firefly.

### DIFF
--- a/suites/upgrade/dumpling-giant-x/stress-split/5-workload/rados_api_tests.yaml
+++ b/suites/upgrade/dumpling-giant-x/stress-split/5-workload/rados_api_tests.yaml
@@ -3,4 +3,4 @@ tasks:
     branch: giant
     clients:
       client.0:
-        - rados/test-upgrade-giant.sh
+        - rados/test-upgrade-firefly.sh

--- a/suites/upgrade/dumpling-giant-x/stress-split/7-workload/rados_api_tests.yaml
+++ b/suites/upgrade/dumpling-giant-x/stress-split/7-workload/rados_api_tests.yaml
@@ -3,4 +3,4 @@ tasks:
     branch: giant
     clients:
       client.0:
-        - rados/test-upgrade-giant.sh
+        - rados/test-upgrade-firefly.sh

--- a/suites/upgrade/dumpling-giant-x/stress-split/9-workload/rados_api_tests.yaml
+++ b/suites/upgrade/dumpling-giant-x/stress-split/9-workload/rados_api_tests.yaml
@@ -3,4 +3,4 @@ tasks:
     branch: giant
     clients:
       client.0:
-        - rados/test-upgrade-giant.sh
+        - rados/test-upgrade-firefly.sh


### PR DESCRIPTION
The changes for firefly upgrade tests apply to giant as well.
