### PR TITLE
Use the correct versions of existing tests

### DIFF
--- a/suites/upgrade/dumpling-giant-x/stress-split/5-workload/rados_api_tests.yaml
+++ b/suites/upgrade/dumpling-giant-x/stress-split/5-workload/rados_api_tests.yaml
@@ -1,6 +1,6 @@
 tasks:
 - workunit:
-    branch: giant
+    branch: dumpling
     clients:
       client.0:
-        - rados/test-upgrade-giant.sh
+        - rados/test-upgrade-firefly.sh

--- a/suites/upgrade/dumpling-giant-x/stress-split/7-workload/rados_api_tests.yaml
+++ b/suites/upgrade/dumpling-giant-x/stress-split/7-workload/rados_api_tests.yaml
@@ -1,6 +1,6 @@
 tasks:
 - workunit:
-    branch: giant
+    branch: dumpling
     clients:
       client.0:
-        - rados/test-upgrade-giant.sh
+        - rados/test-upgrade-firefly.sh

--- a/suites/upgrade/dumpling-giant-x/stress-split/9-workload/rados_api_tests.yaml
+++ b/suites/upgrade/dumpling-giant-x/stress-split/9-workload/rados_api_tests.yaml
@@ -1,6 +1,6 @@
 tasks:
 - workunit:
-    branch: giant
+    branch: dumpling
     clients:
       client.0:
-        - rados/test-upgrade-giant.sh
+        - rados/test-upgrade-firefly.sh


### PR DESCRIPTION
The test-upgrade-firefly.sh script is used from the dumpling suite

Fixes: 9511
Signed-off-by: Warren Usui warren.usui@inktank.com
