### PR TITLE
Fixed upgrade steps flow

### DIFF
--- a/suites/upgrade/dumpling-firefly-x/parallel/3-upgrade-sequence/upgrade-all.yaml
+++ b/suites/upgrade/dumpling-firefly-x/parallel/3-upgrade-sequence/upgrade-all.yaml
@@ -2,5 +2,9 @@ upgrade-sequence0:
    sequential:
    - install.upgrade:
        mon.a:
+         branch: firefly
        mon.b:
+         branch: firefly
+   - print: "**** done install.upgrade firefly for mon.a and mon.b"
    - ceph.restart: [mon.a, mon.b, mon.c, mds.a, osd.0, osd.1, osd.2, osd.3]
+   - print: "**** done ceph.restart the cluster"

--- a/suites/upgrade/dumpling-firefly-x/parallel/4-firefly-upgrade/firefly.yaml
+++ b/suites/upgrade/dumpling-firefly-x/parallel/4-firefly-upgrade/firefly.yaml
@@ -1,14 +1,4 @@
 tasks:
-   - install.upgrade:
-       mon.a:
-         branch: firefly
-       mon.b:
-         branch: firefly
-       client.0:
-         branch: firefly
-   - print: "**** done install.upgrade"
-   - ceph.restart:
-   - print: "**** done restart"
    - parallel:
      - workload2
      - upgrade-sequence


### PR DESCRIPTION
@tmuthamizhan 
@wusui 
@liewegas 

Pls review, this fixed incorrect order of upgrade steps and keeps   'workload' and 'upgrade-sequence0' run in parallel loop 

Signed-off-by: Yuri Weinstein yuri.weinstein@inktank.com
