### PR TITLE
tasks/s3tests: add slow backend configurable

### DIFF
--- a/tasks/s3tests.py
+++ b/tasks/s3tests.py
@@ -246,6 +246,9 @@ def configure(ctx, config):
         else:
             s3tests_conf['DEFAULT']['host'] = 'localhost'
 
+        if properties is not None and 'slow_backend' in properties:
+	    s3tests_conf['fixtures']['slow backend'] = properties['slow_backend']
+
         (remote,) = ctx.cluster.only(client).remotes.keys()
         remote.run(
             args=[


### PR DESCRIPTION
Adding this so that we can modify the clients' conf file as needed with slow backend.
This can be achieved by:

overrides:
  s3tests:
    slow_backend: true

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
