### PR TITLE
multiversion/dumpling-x: remove rgw

### DIFF
--- a/suites/multi-version/dumpling-x/basic/2-workload/rgw_s3tests.yaml
+++ b/suites/multi-version/dumpling-x/basic/2-workload/rgw_s3tests.yaml
@@ -1,5 +1,0 @@
-tasks:
-- rgw: [client.0]
-- s3tests:
-    client.0:
-      rgw_server: client.0


### PR DESCRIPTION
firefly radosgw + dumpling osds won't work.  (Nor will anything newer
than firefly).

Signed-off-by: Sage Weil sage@redhat.com
