### PR TITLE
apache: set MaxRequestsPerChild to 0

### DIFF
--- a/tasks/apache.conf.template
+++ b/tasks/apache.conf.template
@@ -55,3 +55,4 @@ SetEnv RGW_PRINT_CONTINUE {print_continue}
 
 AllowEncodedSlashes On
 ServerSignature Off
+MaxRequestsPerChild 0


### PR DESCRIPTION
Otherwise the default is 10k.

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
