### PR TITLE
rbd/singleton/all/formatted-output: use latest dumplig cli-integration test

### DIFF
--- a/suites/rbd/singleton/all/formatted-output.yaml
+++ b/suites/rbd/singleton/all/formatted-output.yaml
@@ -6,4 +6,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - https://ceph.com/git/?p=ceph.git;a=blob_plain;;hb=c7a0477bad6bfbec4ef325295ca0489ec197792;f=src/test/cli-integration/rbd/formatted-output.t
+      - https://ceph.com/git/?p=ceph.git;a=blob_plain;hb=dumpling;f=src/test/cli-integration/rbd/formatted-output.t


### PR DESCRIPTION
...which is fixed up to work on trusty hosts.

Signed-off-by: Sage Weil sage@redhat.com
