### PR TITLE
rgw: mark ec related rgw suites as slow backend

### DIFF
--- a/rgw_pool_type/ec-cache.yaml
+++ b/rgw_pool_type/ec-cache.yaml
@@ -2,3 +2,5 @@ overrides:
   rgw:
     ec-data-pool: true
     cache-pools: true
+  s3tests:
+    slow_backend: true

--- a/rgw_pool_type/ec-profile.yaml
+++ b/rgw_pool_type/ec-profile.yaml
@@ -6,3 +6,5 @@ overrides:
       k: 3
       m: 1
       ruleset-failure-domain: osd
+  s3tests:
+    slow_backend: true

--- a/rgw_pool_type/ec.yaml
+++ b/rgw_pool_type/ec.yaml
@@ -1,3 +1,5 @@
 overrides:
   rgw:
     ec-data-pool: true
+  s3tests:
+    slow_backend: true


### PR DESCRIPTION
We want to avoid tests that time out due to a too slow backend.

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
