### PR TITLE
Correct: Thrasher: Disable ceph_objectstore_tool tests if old release mi...

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -59,11 +59,6 @@ def mount_osd_data(ctx, remote, osd):
             )
 
 
-def cmd_exists(cmd):
-    return subprocess.call("type " + cmd, shell=True,
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
-
-
 class Thrasher:
     """
     Object used to thrash Ceph
@@ -84,10 +79,6 @@ class Thrasher:
             self.revive_timeout += 120
         self.clean_wait = self.config.get('clean_wait', 0)
         self.minin = self.config.get("min_in", 3)
-        if cmd_exists("ceph_objectstore_tool"):
-            self.ceph_objectstore_tool = self.config.get('ceph_objectstore_tool', False)
-        else:
-            self.ceph_objectstore_tool = False
         self.chance_move_pg = self.config.get('chance_move_pg', 1.0)
 
         num_osds = self.in_osds + self.out_osds
@@ -112,6 +103,20 @@ class Thrasher:
             manager.raw_cluster_cmd('--', 'mon', 'tell', '*', 'injectargs',
                                     '--mon-osd-down-out-interval 0')
         self.thread = gevent.spawn(self.do_thrash)
+        if self.cmd_exists_on_osds("ceph_objectstore_tool"):
+            self.ceph_objectstore_tool = self.config.get('ceph_objectstore_tool', False)
+        else:
+            self.ceph_objectstore_tool = False
+            self.log("Unable to test ceph_objectstore_tool, not available on all OSD nodes")
+
+    def cmd_exists_on_osds(self, cmd):
+        allremotes = self.ceph_manager.ctx.cluster.only(teuthology.is_type('osd')).remotes.keys()
+        allremotes = list(set(allremotes))
+        for remote in allremotes:
+            proc = remote.run(args=['type', cmd], check_status=False, stdout=StringIO(), stderr=StringIO())
+            if proc.exitstatus != 0:
+                return False;
+        return True;
 
     def kill_osd(self, osd=None, mark_down=False, mark_out=False):
         """


### PR DESCRIPTION
...ssing command

Require ceph_objectstore_tool to be available on all OSD nodes
Log a message when tool is not available

Signed-off-by: David Zafman dzafman@redhat.com
