### PR TITLE
tasks/cephfs/mount: use seperate for testing flock and posix lock

### DIFF
--- a/tasks/mds_client_recovery.py
+++ b/tasks/mds_client_recovery.py
@@ -335,7 +335,7 @@ class TestClientRecovery(CephFSTestCase):
         # =====================================
         lock_holder = self.mount_a.lock_background()
 
-        self.mount_b.wait_for_visible();
+        self.mount_b.wait_for_visible("background_file-2");
         self.mount_b.check_filelock();
 
         self.fs.mds_stop()


### PR DESCRIPTION
Old version libfuse treats both flock and posix lock requests as posix
lock request. This is a workaround for the bug.

Fixes: #9995
Signed-off-by: Yan, Zheng zyan@redhat.com
