### PR TITLE
Removed mon_thrash tests from rgw part to fix #9899

### DIFF
--- a/suites/upgrade/dumpling/rgw/4-final/monthrash.yaml
+++ b/suites/upgrade/dumpling/rgw/4-final/monthrash.yaml
@@ -1,7 +1,8 @@
 tasks:
-- mon_thrash:
-    revive_delay: 20
-    thrash_delay: 1
+#removed to fix #9899
+#- mon_thrash:
+#    revive_delay: 20
+#    thrash_delay: 1
 - install.upgrade:
     client.0:
       branch: dumpling


### PR DESCRIPTION
@liewegas removed mon_thrash from the rgw/ section, pls review

Signed-off-by: Yuri Weinstein yuri.weinstein@inktank.com
