### PR TITLE
tasks/watch_notify_same_primary: fix test for new watch/notify

### DIFF
--- a/tasks/watch_notify_same_primary.py
+++ b/tasks/watch_notify_same_primary.py
@@ -97,8 +97,15 @@ def task(ctx, config):
 
         for watch in watches:
             lines = watch.stdout.getvalue().split("\n")
-            print lines
-            assert len(lines) == 4
+            got1 = False
+            got2 = False
+            for l in lines:
+                if 'notify1' in l:
+                    got1 = True
+                if 'notify2' in l:
+                    got2 = True
+            log.info(lines)
+            assert got1 and got2
 
         ctx.manager.revive_osd(0)
         ctx.manager.remove_pool(pool)


### PR DESCRIPTION
It now checks for 'notify1' and 'notify2' strings, allowing it to work
on both old and new versions of rados watch command.

Signed-off-by: Sage Weil sage@redhat.com
