### PR TITLE
radosgw-admin: wait before trimming usage

### DIFF
--- a/tasks/radosgw_admin.py
+++ b/tasks/radosgw_admin.py
@@ -825,6 +825,10 @@ def task(ctx, config):
         assert entry['category'] == cat
         assert entry['successful_ops'] > 0
 
+    # the usage flush interval is 30 seconds, wait that much an then some
+    # to make sure everything has been flushed
+    time.sleep(35)
+
     # TESTCASE 'usage-trim' 'usage' 'trim' 'user usage' 'succeeds, usage removed'
     (err, out) = rgwadmin(ctx, client, ['usage', 'trim', '--uid', user1],
         check_status=True)


### PR DESCRIPTION
Fixes: #9892

Need to wait through the usage interval before trimming usage, otherwise we might not
remove all pending usage info.

Backport: dumpling, firefly, giant

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
(cherry picked from commit dd09ecbfab8a659f3faaf879a52849caab5e8e8e)
