### PR TITLE
Use qemu-kvm in the qemu task for rpm based systems.

### DIFF
--- a/tasks/qemu.py
+++ b/tasks/qemu.py
@@ -169,14 +169,20 @@ def run_qemu(ctx, config):
                 ]
             )
 
-        base_file = '{tdir}/qemu/base.{client}.qcow2'.format(tdir=testdir, client=client)
+        base_file = '{tdir}/qemu/base.{client}.qcow2'.format(
+            tdir=testdir,
+            client=client
+        )
+        qemu_cmd = 'qemu-system-x86_64'
+        if remote.os.package_type == "rpm":
+            qemu_cmd = "/usr/libexec/qemu-kvm"
         args=[
             'adjust-ulimits',
             'ceph-coverage',
             '{tdir}/archive/coverage'.format(tdir=testdir),
             'daemon-helper',
             'term',
-            'qemu-system-x86_64', '-enable-kvm', '-nographic',
+            qemu_cmd, '-enable-kvm', '-nographic',
             '-m', str(client_config.get('memory', DEFAULT_MEM)),
             # base OS device
             '-drive',


### PR DESCRIPTION
This resolves these two tracker issues:

http://tracker.ceph.com/issues/10275
http://tracker.ceph.com/issues/10276

Even though we are now using qemu-kvm, the version that is install wasn't compiled with rbd support so qemu tests will still fail when starting up qemu.  I've cut another ticket (http://tracker.ceph.com/issues/10480) to fix this as it can't be done in ceph-qa-suite.