### PR TITLE
suites/fs: isolate quota task

### DIFF
--- a/suites/fs/basic/tasks/cfuse_workunit_misc.yaml
+++ b/suites/fs/basic/tasks/cfuse_workunit_misc.yaml
@@ -6,8 +6,3 @@ tasks:
       all:
         - fs/misc
 
-overrides:
-  ceph:
-    conf:
-      client:
-        client quota: true

--- a/suites/fs/basic/tasks/cfuse_workunit_quota.yaml
+++ b/suites/fs/basic/tasks/cfuse_workunit_quota.yaml
@@ -1,0 +1,13 @@
+tasks:
+- ceph-fuse:
+- workunit:
+    timeout: 6h
+    clients:
+      all:
+        - fs/quota
+
+overrides:
+  ceph:
+    conf:
+      client:
+        client quota: true


### PR DESCRIPTION
Quota script is moved out of fs/misc so that kclient
doesn't try to run it.  Update cfuse suite to find
the new location, and only enable quota for this
one script rather than enabling across
all misc tests.

Fixes: #10579
Signed-off-by: John Spray <john.spray@redhat.com>