### PR TITLE
teuthology: some suites still use http://ceph.newdream.net

### DIFF
--- a/suites/powercycle/osd/tasks/admin_socket_objecter_requests.yaml
+++ b/suites/powercycle/osd/tasks/admin_socket_objecter_requests.yaml
@@ -10,4 +10,4 @@ tasks:
 - admin_socket:
     client.0:
       objecter_requests:
-        test: "http://ceph.newdream.net/git/?p=ceph.git;a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"
+        test: "http://ceph.com/git/?p=ceph.git;a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"

--- a/suites/rados/thrash/workloads/admin_socket_objecter_requests.yaml
+++ b/suites/rados/thrash/workloads/admin_socket_objecter_requests.yaml
@@ -10,4 +10,4 @@ tasks:
 - admin_socket:
     client.0:
       objecter_requests:
-        test: "http://ceph.newdream.net/git/?p=ceph.git;a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"
+        test: "http://ceph.com/git/?p=ceph.git;a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"

--- a/tasks/restart.py
+++ b/tasks/restart.py
@@ -49,7 +49,7 @@ def get_tests(ctx, config, role, remote, testdir):
             run.Raw('&&'),
             'git',
             'archive',
-            '--remote=git://ceph.newdream.net/git/ceph.git',
+            '--remote=git://ceph.com/git/ceph.git',
             '%s:qa/workunits' % refspec,
             run.Raw('|'),
             'tar',

--- a/tasks/workunit.py
+++ b/tasks/workunit.py
@@ -295,7 +295,7 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
             run.Raw('&&'),
             'git',
             'archive',
-            '--remote=git://ceph.newdream.net/git/ceph.git',
+            '--remote=git://ceph.com/git/ceph.git',
             '%s:qa/workunits' % refspec,
             run.Raw('|'),
             'tar',


### PR DESCRIPTION
This probably redirects to http://ceph.com but ceph.newdream.net still appears in some places

http://tracker.ceph.com/issues/9922 Fixes: #9922

Signed-off-by: Armando Segnini  <armando.segnini@telecom-bretagne.eu>