### PR TITLE
mds_scrub_checks: only direct ops at the active MDS

### DIFF
--- a/suites/fs/basic/tasks/cephfs_scrub_tests.yaml
+++ b/suites/fs/basic/tasks/cephfs_scrub_tests.yaml
@@ -7,7 +7,7 @@ overrides:
 tasks:
 - ceph-fuse:
 - mds_scrub_checks:
-    mds_id: a
+    mds_rank: 0
     path: /scrub/test/path
     client: 0
     run_seq: 0
@@ -15,7 +15,7 @@ tasks:
     clients:
       client.0: [suites/pjd.sh]
 - mds_scrub_checks:
-    mds_id: a
+    mds_rank: 0
     path: /scrub/test/path
     client: 0
     run_seq: 1


### PR DESCRIPTION
Change the config option from mds_id to mds_rank to reflect the
fact that it's the rank we want to make use of (and will continue
to want when we're doing stuff like force exporting from one rank
to another).

Fixes: #10361

Signed-off-by: Greg Farnum <gfarnum@redhat.com>