### PR TITLE
drop tiobench tests

### DIFF
--- a/suites/fs/basic/tasks/cfuse_workunit_suites_tiobench.yaml
+++ b/suites/fs/basic/tasks/cfuse_workunit_suites_tiobench.yaml
@@ -1,8 +1,0 @@
-tasks:
-- install:
-- ceph:
-- ceph-fuse:
-- workunit:
-    clients:
-      all:
-        - suites/tiobench.sh

--- a/suites/fs/samba/workload/cifs-tiobench.yaml
+++ b/suites/fs/samba/workload/cifs-tiobench.yaml
@@ -1,8 +1,0 @@
-tasks:
-- cifs-mount:
-    client.1:
-      share: ceph
-- workunit:
-    clients:
-      client.1:
-        - suites/tiobench.sh

--- a/suites/fs/traceless/tasks/cfuse_workunit_suites_tiobench.yaml
+++ b/suites/fs/traceless/tasks/cfuse_workunit_suites_tiobench.yaml
@@ -1,8 +1,0 @@
-tasks:
-- install:
-- ceph:
-- ceph-fuse:
-- workunit:
-    clients:
-      all:
-        - suites/tiobench.sh

--- a/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_tiobench.yaml
+++ b/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_tiobench.yaml
@@ -1,8 +1,0 @@
-tasks:
-- install:
-- ceph:
-- kclient:
-- workunit:
-    clients:
-      all:
-        - suites/tiobench.sh

--- a/suites/krbd/rbd/tasks/rbd_workunit_suites_tiobench.yaml
+++ b/suites/krbd/rbd/tasks/rbd_workunit_suites_tiobench.yaml
@@ -1,9 +1,0 @@
-tasks:
-- install:
-- ceph:
-- rbd:
-    all:
-- workunit:
-    clients:
-      all:
-        - suites/tiobench.sh

--- a/suites/rbd/librbd/workloads/qemu_tiobench.yaml
+++ b/suites/rbd/librbd/workloads/qemu_tiobench.yaml
@@ -1,5 +1,0 @@
-tasks:
-- qemu:
-    all:
-      test: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=qa/workunits/suites/tiobench.sh
-exclude_arch: armv7l

--- a/suites/upgrade-fs/fs/5-next-workload/tiobench.yaml
+++ b/suites/upgrade-fs/fs/5-next-workload/tiobench.yaml
@@ -1,6 +1,0 @@
-tasks:
-- workunit:
-     branch: next
-     clients:
-        all:
-           - suites/tiobench.sh


### PR DESCRIPTION
The tiobench software has been abandoned upstream for years. Fedora and
Debian are no longer shipping the tiobench package, so we've had to
carry the package ourselves in the Ceph project, and we're trying to
slim down our dependencies where it makes sense to do so.

Nuke the tiobench tests.

http://tracker.ceph.com/issues/10152 Refs: #10152

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>
(cherry picked from commit 8a317125fc542667e57c66017db6e80a3edc24f2)