### PR TITLE
rbd: get src/test/cli-integration/rbd/formatted-output.t from giant

### DIFF
--- a/suites/rbd/singleton/all/formatted-output.yaml
+++ b/suites/rbd/singleton/all/formatted-output.yaml
@@ -6,4 +6,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - https://ceph.com/git/?p=ceph.git;a=blob_plain;f=src/test/cli-integration/rbd/formatted-output.t
+      - https://ceph.com/git/?p=ceph.git;a=blob_plain;hb=giant;f=src/test/cli-integration/rbd/formatted-output.t


### PR DESCRIPTION
Instead of fetching it from the tip of the master branch.

Signed-off-by: Loic Dachary <ldachary@redhat.com>