### PR TITLE
Mirror the supported distros used in nightlies in the teuthology suite

### DIFF
--- a/suites/teuthology/no-ceph/distros/ubuntu12.04.yaml
+++ b/suites/teuthology/no-ceph/distros/ubuntu12.04.yaml
@@ -1,0 +1,2 @@
+os_type: ubuntu
+os_version: "12.04"

--- a/suites/teuthology/no-ceph/distros/vps_centos6.5.yaml
+++ b/suites/teuthology/no-ceph/distros/vps_centos6.5.yaml
@@ -1,0 +1,3 @@
+machine_type: vps
+os_type: centos 
+os_version: "6.5"

--- a/suites/teuthology/no-ceph/distros/vps_debian7.yaml
+++ b/suites/teuthology/no-ceph/distros/vps_debian7.yaml
@@ -1,0 +1,3 @@
+machine_type: vps
+os_type: debian 
+os_version: "7.0"

--- a/suites/teuthology/no-ceph/distros/vps_rhel6.4.yaml
+++ b/suites/teuthology/no-ceph/distros/vps_rhel6.4.yaml
@@ -1,0 +1,3 @@
+machine_type: vps
+os_type: rhel 
+os_version: "6.4"

--- a/suites/teuthology/no-ceph/distros/vps_rhel6.5.yaml
+++ b/suites/teuthology/no-ceph/distros/vps_rhel6.5.yaml
@@ -1,0 +1,3 @@
+machine_type: vps
+os_type: rhel 
+os_version: "6.5"


### PR DESCRIPTION
I decided not to symlink because I'm using a file name convention to
easily filter out distros that need a vps.
