### PR TITLE
Hadoop workunits

### DIFF
--- a/suites/hadoop/basic/tasks/repl.yaml
+++ b/suites/hadoop/basic/tasks/repl.yaml
@@ -3,6 +3,6 @@ tasks:
 - install:
 - ceph:
 - hadoop:
-- workunit: 
+- workunit:
     clients:
-      client.0: [hadoop/internal-tests.sh]
+      client.0: [hadoop/repl.sh]

--- a/suites/hadoop/basic/tasks/terasort.yaml
+++ b/suites/hadoop/basic/tasks/terasort.yaml
@@ -1,0 +1,10 @@
+tasks:
+- ssh_keys:
+- install:
+- ceph:
+- hadoop:
+- workunit: 
+    clients:
+      client.0: [hadoop/terasort.sh]
+    env:
+      NUM_RECORDS: "10000000"


### PR DESCRIPTION
Fixes internal-tests, and adds terasort. Depends on hadoop-workunit PR in ceph repo.