### PR TITLE
ceph: ps axf too before lsof

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -776,6 +776,8 @@ def cluster(ctx, config):
                     remote.run(args=[
                             'sudo',
                             run.Raw('PATH=/usr/sbin:$PATH'),
+                            'ps', 'auxf',
+                            run.Raw(';'),
                             'lsof'
                             ])
                     raise e


### PR DESCRIPTION
Specifically, I want to know *who* is running the ceph-osd that is holding
the files open.

Signed-off-by: Sage Weil <sage@redhat.com>