### PR TITLE
Use an NFS mount instead of virtio-9p in the qemu task

### DIFF
--- a/tasks/userdata_setup.yaml
+++ b/tasks/userdata_setup.yaml
@@ -13,9 +13,12 @@
 - |
   #!/bin/bash
 
-  # mount a 9p fs for storing logs
+  # mount a NFS share for storing logs
+  apt-get update
+  apt-get -y install nfs-common
   mkdir /mnt/log
-  mount -t 9p -o trans=virtio test_log /mnt/log
+  # 10.0.2.2 is the host
+  mount -v -t nfs -o proto=tcp 10.0.2.2:{mnt_dir} /mnt/log
 
   # mount the iso image that has the test script
   mkdir /mnt/cdrom


### PR DESCRIPTION
RHEL 7.0 doesn't have virtio-9p, so we switched to using an nfs mount so that the guest can share files with the host during the qemu tasks.  This will work across all distros.

Tested in octo for both rhel and ubuntu.

http://pulpito.ceph.redhat.com/qemu-rhel-issue-10680/
http://pulpito.ceph.redhat.com/qemu-ubuntu-issue-10680/ 