### PR TITLE
Thrasher: log backtrace of thrown exception

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -2,6 +2,7 @@
 ceph manager -- Thrasher and CephManager objects
 """
 from cStringIO import StringIO
+from functools import wraps
 import contextlib
 import random
 import time
@@ -9,6 +10,7 @@ import gevent
 import base64
 import json
 import threading
+import traceback
 import os
 from teuthology import misc as teuthology
 from tasks.scrub import Scrubber
@@ -621,6 +623,17 @@ class Thrasher:
             val -= prob
         return None
 
+    def log_exc(func):
+        @wraps(func)
+        def wrapper(self):
+            try:
+                return func(self)
+            except:
+                self.log(traceback.format_exc())
+                raise
+        return wrapper
+
+    @log_exc
     def do_thrash(self):
         """
         Loop to select random actions to thrash ceph manager with.


### PR DESCRIPTION
* add a wrapper to log uncaught exception to self.logger, greenlet also
  prints the backtrace and exception to stderr, but teuthology.log does
  not capture stderr. so we need to catch them by ourselves to reveal
  more info to root-cause this issue.
* log uncaught exception thrown by Thrasher.do_thrash() to self.log.

See: #10630
Signed-off-by: Kefu Chai <kchai@redhat.com>