### PR TITLE
apache: change template to load mpm worker module (part 2)

### DIFF
--- a/tasks/apache.conf.template
+++ b/tasks/apache.conf.template
@@ -29,7 +29,6 @@ ServerName {host}
   </IfModule>
   User {user}
   Group {group}
-  {apache24_modconfig}
 </IfVersion>
 
 ServerRoot {testdir}/apache


### PR DESCRIPTION
3db4d6f93ba3e58b652c3dadefe5c545bd94a2a3 was incorrectly cherry picked
in 563eb8ce1b7c04948908998d8421e1fedebd403f and misses the removal of
{apache24_modconfig}. As a consequence, the MPM module is loaded
twice:

   apache2: Configuration error: More than one MPM loaded.

http://tracker.ceph.com/issues/10801 Fixes: #10801

Signed-off-by: Loic Dachary <loic@dachary.org>