### PR TITLE
impelement a tox job to catch bad linter errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
 .*.sw[nmop]
 *.pyc
+.tox
 __pycache__

--- a/tasks/calamari_setup.py
+++ b/tasks/calamari_setup.py
@@ -4,7 +4,6 @@ Calamari setup task
 import contextlib
 import logging
 import os
-import re
 import requests
 import shutil
 import subprocess

--- a/tasks/ceph_deploy.py
+++ b/tasks/ceph_deploy.py
@@ -222,7 +222,7 @@ def build_ceph_cluster(ctx, config):
         # If the following fails, it is OK, it might just be that the monitors
         # are taking way more than a minute/monitor to form quorum, so lets
         # try the next block which will wait up to 15 minutes to gatherkeys.
-        estatus_mon = execute_ceph_deploy(ctx, config, mon_create_nodes)
+        execute_ceph_deploy(ctx, config, mon_create_nodes)
 
         estatus_gather = execute_ceph_deploy(ctx, config, gather_keys)
         max_gather_tries = 90

--- a/tasks/ceph_fuse.py
+++ b/tasks/ceph_fuse.py
@@ -6,7 +6,6 @@ import contextlib
 import logging
 
 from teuthology import misc as teuthology
-from teuthology.orchestra import run
 from cephfs.fuse_mount import FuseMount
 
 log = logging.getLogger(__name__)
@@ -14,8 +13,8 @@ log = logging.getLogger(__name__)
 
 def get_client_configs(ctx, config):
     """
-    Get a map of the configuration for each FUSE client in the configuration
-    by combining the configuration of the current task with any global overrides.
+    Get a map of the configuration for each FUSE client in the configuration by
+    combining the configuration of the current task with any global overrides.
 
     :param ctx: Context instance
     :param config: configuration for this task

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -9,6 +9,7 @@ import time
 import gevent
 import base64
 import json
+import logging
 import threading
 import traceback
 import os
@@ -17,10 +18,11 @@ from tasks.scrub import Scrubber
 from util.rados import cmd_erasure_code_profile
 from teuthology.orchestra.remote import Remote
 from teuthology.orchestra import run
-import subprocess
 
 
 DEFAULT_CONF_PATH = '/etc/ceph/ceph.conf'
+
+log = logging.getLogger(__name__)
 
 
 def write_conf(ctx, conf_path=DEFAULT_CONF_PATH):

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -713,7 +713,7 @@ class ObjectStoreTool:
                       options=options))
         if stdin:
             cmd = ("echo {payload} | base64 --decode | {cmd}".
-                   format(payload=base64.encode(kwargs['stdin']),
+                   format(payload=base64.encode(stdin),
                           cmd=cmd))
         lines.append(cmd)
         return "\n".join(lines)

--- a/tasks/cephfs/mount.py
+++ b/tasks/cephfs/mount.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-from cStringIO import StringIO
 import logging
 import datetime
 import time

--- a/tasks/cephfs/mount.py
+++ b/tasks/cephfs/mount.py
@@ -226,7 +226,7 @@ class CephFSMount(object):
             """).format(path=path)
 
         log.info("check lock on file {0}".format(basename))
-        r = self.client_remote.run(args=[
+        self.client_remote.run(args=[
             'sudo', 'python', '-c', pyscript
         ])
 

--- a/tasks/divergent_priors.py
+++ b/tasks/divergent_priors.py
@@ -4,7 +4,6 @@ Special case divergence test
 import logging
 import time
 
-import ceph_manager
 from teuthology import misc as teuthology
 from util.rados import rados
 
@@ -54,6 +53,8 @@ def task(ctx, config):
     non_divergent.remove(divergent)
 
     log.info('writing initial objects')
+    first_mon = teuthology.get_first_mon(ctx, config)
+    (mon,) = ctx.cluster.only(first_mon).remotes.iterkeys()
     # write 1000 objects
     for i in range(1000):
         rados(ctx, mon, ['-p', 'foo', 'put', 'existing_%d' % i, dummyfile])

--- a/tasks/osd_failsafe_enospc.py
+++ b/tasks/osd_failsafe_enospc.py
@@ -5,7 +5,6 @@ from cStringIO import StringIO
 import logging
 import time
 
-import ceph_manager
 from teuthology.orchestra import run
 from util.rados import rados
 from teuthology import misc as teuthology
@@ -51,6 +50,9 @@ def task(ctx, config):
 
     # State NONE -> NEAR
     log.info('1. Verify warning messages when exceeding nearfull_ratio')
+
+    first_mon = teuthology.get_first_mon(ctx, config)
+    (mon,) = ctx.cluster.only(first_mon).remotes.iterkeys()
 
     proc = mon.run(
              args=[

--- a/tasks/peering_speed_test.py
+++ b/tasks/peering_speed_test.py
@@ -3,8 +3,6 @@ Remotely run peering tests.
 """
 import logging
 import time
-from teuthology import misc as teuthology
-import ceph_manager
 
 log = logging.getLogger(__name__)
 

--- a/tasks/populate_rbd_pool.py
+++ b/tasks/populate_rbd_pool.py
@@ -3,8 +3,6 @@ Populate rbd pools
 """
 import contextlib
 import logging
-from ceph_manager import CephManager
-from teuthology import misc as teuthology
 
 log = logging.getLogger(__name__)
 
@@ -77,7 +75,7 @@ def task(ctx, config):
                         imagename
                         ])
                 bench_run()
-            
+
     try:
         yield
     finally:

--- a/tasks/repair_test.py
+++ b/tasks/repair_test.py
@@ -3,7 +3,6 @@ Test pool repairing after objects are damaged.
 """
 import logging
 import time
-import contextlib
 
 import ceph_manager
 from teuthology import misc as teuthology

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = flake8
+skipsdist = True
+
+[testenv:flake8]
+deps=
+  flake8
+commands=flake8 --select=F


### PR DESCRIPTION
This PR adds a `tox.ini` and fixes all the `F` class errors that are usually the worst (most of them will cause code to break).

Issue link: http://tracker.ceph.com/issues/10954

Output examples for before/after

Before:

    tox -r
    flake8 create: /Users/alfredo/python/upstream/ceph-qa-suite/.tox/flake8
    flake8 installdeps: flake8
    flake8 runtests: PYTHONHASHSEED='2738397779'
    flake8 runtests: commands[0] | flake8 --select=F
    ./tasks/ceph_fuse.py:9:1: F401 'run' imported but unused
    ./tasks/calamari_setup.py:7:1: F401 're' imported but unused
    ./tasks/divergent_priors.py:7:1: F401 'ceph_manager' imported but unused
    ./tasks/divergent_priors.py:8:1: F401 'teuthology' imported but unused
    ./tasks/divergent_priors.py:59:20: F821 undefined name 'mon'
    ./tasks/divergent_priors.py:71:14: F821 undefined name 'mon'
    ./tasks/divergent_priors.py:74:5: F821 undefined name 'mon'
    ./tasks/divergent_priors.py:101:16: F821 undefined name 'mon'
    ./tasks/divergent_priors.py:123:16: F821 undefined name 'mon'
    ./tasks/divergent_priors.py:135:30: F821 undefined name 'mon'
    ./tasks/ceph_deploy.py:225:9: F841 local variable 'estatus_mon' is assigned to but never used
    ./tasks/peering_speed_test.py:6:1: F401 'teuthology' imported but unused
    ./tasks/peering_speed_test.py:7:1: F401 'ceph_manager' imported but unused
    ./tasks/populate_rbd_pool.py:6:1: F401 'CephManager' imported but unused
    ./tasks/populate_rbd_pool.py:7:1: F401 'teuthology' imported but unused
    ./tasks/osd_failsafe_enospc.py:8:1: F401 'ceph_manager' imported but unused
    ./tasks/osd_failsafe_enospc.py:11:1: F401 'teuthology' imported but unused
    ./tasks/osd_failsafe_enospc.py:55:12: F821 undefined name 'mon'
    ./tasks/osd_failsafe_enospc.py:82:12: F821 undefined name 'mon'
    ./tasks/osd_failsafe_enospc.py:107:22: F821 undefined name 'mon'
    ./tasks/osd_failsafe_enospc.py:118:22: F821 undefined name 'mon'
    ./tasks/osd_failsafe_enospc.py:123:12: F821 undefined name 'mon'
    ./tasks/osd_failsafe_enospc.py:151:12: F821 undefined name 'mon'
    ./tasks/osd_failsafe_enospc.py:181:12: F821 undefined name 'mon'
    ./tasks/repair_test.py:6:1: F401 'contextlib' imported but unused
    ./tasks/ceph_manager.py:20:1: F401 'subprocess' imported but unused
    ./tasks/ceph_manager.py:67:5: F821 undefined name 'log'
    ./tasks/ceph_manager.py:76:9: F821 undefined name 'log'
    ./tasks/ceph_manager.py:714:49: F821 undefined name 'kwargs'
    ./tasks/cephfs/mount.py:8:1: F811 redefinition of unused 'StringIO' from line 2
    ./tasks/cephfs/mount.py:230:9: F841 local variable 'r' is assigned to but never used
    ERROR: InvocationError: '/Users/alfredo/python/upstream/ceph-qa-suite/.tox/flake8/bin/flake8 --select=F'
    ______________________________________________________ summary _______________________________________________________
    ERROR:   flake8: commands failed

After:

    tox -r
    flake8 recreate: /Users/alfredo/python/upstream/ceph-qa-suite/.tox/flake8
    flake8 installdeps: flake8
    flake8 runtests: PYTHONHASHSEED='2705998827'
    flake8 runtests: commands[0] | flake8 --select=F
    ______________________________________________________ summary _______________________________________________________
      flake8: commands succeeded
      congratulations :)
