### PR TITLE
Fixes #11013, use time.sleep instead of manager.sleep which isn't there.

### DIFF
--- a/tasks/lost_unfound.py
+++ b/tasks/lost_unfound.py
@@ -2,6 +2,7 @@
 Lost_unfound
 """
 import logging
+import time
 import ceph_manager
 from teuthology import misc as teuthology
 from util.rados import rados
@@ -29,7 +30,7 @@ def task(ctx, config):
         )
 
     while len(manager.get_osd_status()['up']) < 3:
-        manager.sleep(10)
+        time.sleep(10)
     manager.raw_cluster_cmd('tell', 'osd.0', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.1', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.2', 'flush_pg_stats')


### PR DESCRIPTION
Fixes http://tracker.ceph.com/issues/11013

Signed-off-by: Andrew Schoen <aschoen@redhat.com>