### PR TITLE
whitelist shard missing errors

### DIFF
--- a/suites/rados/thrash/workloads/ec-radosbench.yaml
+++ b/suites/rados/thrash/workloads/ec-radosbench.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - shard.*missing
 tasks:
 - radosbench:
     clients: [client.0]


### PR DESCRIPTION
If a shard is missing during a radosbench it can safely be
ignored. It will either be recovered and radosbench will complete
successfully. Or there are too many shard missing to recover the object
and radosbench will fail. Either way we can rely on radosbench to
accurately report success or failure.

Signed-off-by: Loic Dachary <loic@dachary.org>