### PR TITLE
create a new get_acl helper to ensure proper xml is compared

### DIFF
--- a/tasks/radosgw_admin.py
+++ b/tasks/radosgw_admin.py
@@ -35,6 +35,26 @@ def successful_ops(out):
     return entry['total']['successful_ops']
 
 
+def get_acl(key):
+    """
+    Helper function to get the xml acl from a key, ensuring that the xml
+    version tag is removed from the acl response
+    """
+    raw_acl = key.get_xml_acl()
+
+    def remove_version(string):
+        return string.split(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+        )[-1]
+
+    def remove_newlines(string):
+        return string.strip('\n')
+
+    return remove_version(
+        remove_newlines(raw_acl)
+    )
+
+
 def task(ctx, config):
     """
     Test radosgw-admin functionality against a running rgw instance.
@@ -903,7 +923,7 @@ def task(ctx, config):
         ['policy', '--bucket', bucket.name, '--object', key.key],
         check_status=True)
 
-    acl = key.get_xml_acl()
+    acl = get_acl(key)
 
     assert acl == out.strip('\n')
 
@@ -914,7 +934,8 @@ def task(ctx, config):
         ['policy', '--bucket', bucket.name, '--object', key.key],
         check_status=True)
 
-    acl = key.get_xml_acl()
+    acl = get_acl(key)
+
     assert acl == out.strip('\n')
 
     # TESTCASE 'rm-bucket', 'bucket', 'rm', 'bucket with objects', 'succeeds'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[tox]
+skipsdist = True


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>
(cherry picked from commit 9b6ff638735d03c1f3304198fad51ca701a2c8bd)

Conflicts:
	tasks/radosgw_admin.py
          the context changed but the patch seems otherwise good