### PR TITLE
fs: fix up dd testing again

### DIFF
--- a/suites/fs/basic/tasks/cfuse_workunit_suites_truncate_delay.yaml
+++ b/suites/fs/basic/tasks/cfuse_workunit_suites_truncate_delay.yaml
@@ -10,7 +10,6 @@ tasks:
 - ceph-fuse:
 - exec:
     client.0:
-      - cd $TESTDIR/mnt.*
-      - dd if=/dev/zero of=./foo count=100
+      - cd $TESTDIR/mnt.* && dd if=/dev/zero of=./foo count=100
       - sleep 2
-      - truncate --size 0 ./foo
+      - cd $TESTDIR/mnt.* && truncate --size 0 ./foo


### PR DESCRIPTION
We need to change into the directory during the same shell session as we actually
run the dd...

Fixes: #10861

Backport: hammer, giant, firefly

Signed-off-by: Greg Farnum <gfarnum@redhat.com>