### PR TITLE
erasure-code: enable ec-rados-default.yaml

### DIFF
--- a/erasure-code/ec-rados-default.yaml
+++ b/erasure-code/ec-rados-default.yaml
@@ -1,19 +1,18 @@
-workload:
-  sequential:
-    - rados:
-       clients: [client.0]
-       ops: 4000
-       objects: 50
-       ec_pool: true
-       op_weights:
-         read: 100
-         write: 0
-         append: 100
-         delete: 50
-         snap_create: 50
-         snap_remove: 50
-         rollback: 50
-         copy_from: 50
-         setattr: 25
-         rmattr: 25
-    - print: "**** done rados ec sequential"
+tasks:
+  - rados:
+      clients: [client.0]
+      ops: 4000
+      objects: 50
+      ec_pool: true
+      op_weights:
+        read: 100
+        write: 0
+        append: 100
+        delete: 50
+        snap_create: 50
+        snap_remove: 50
+        rollback: 50
+        copy_from: 50
+        setattr: 25
+        rmattr: 25
+  - print: "**** done rados ec task"

--- a/erasure-code/ec-rados-sequential.yaml
+++ b/erasure-code/ec-rados-sequential.yaml
@@ -1,0 +1,19 @@
+workload:
+  sequential:
+    - rados:
+       clients: [client.0]
+       ops: 4000
+       objects: 50
+       ec_pool: true
+       op_weights:
+         read: 100
+         write: 0
+         append: 100
+         delete: 50
+         snap_create: 50
+         snap_remove: 50
+         rollback: 50
+         copy_from: 50
+         setattr: 25
+         rmattr: 25
+    - print: "**** done rados ec sequential"

--- a/suites/upgrade/giant-x/parallel/2-workload/sequential_run/ec-rados-default.yaml
+++ b/suites/upgrade/giant-x/parallel/2-workload/sequential_run/ec-rados-default.yaml
@@ -1,1 +1,0 @@
-../../../../../../erasure-code/ec-rados-default.yaml

--- a/suites/upgrade/giant-x/parallel/2-workload/sequential_run/ec-rados-sequential.yaml
+++ b/suites/upgrade/giant-x/parallel/2-workload/sequential_run/ec-rados-sequential.yaml
@@ -1,0 +1,1 @@
+../../../../../../erasure-code/ec-rados-sequential.yaml


### PR DESCRIPTION
The ec-rados-default.yaml started with:

  workload:
    sequential:

which is only suitable for suites/upgrade/giant-x/parallel/2-workload/sequential_run/ec-rados-default.yaml

because suites/upgrade/giant-x/parallel/1-giant-install/giant.yaml has

   - parallel:
      - workload
      - upgrade-sequence

The same file was included in contexts where the parallel task was not
used and the workload did not run:

  ./suites/upgrade/firefly-x/stress-split-erasure-code/5-workload/ec-rados-default.yaml
  ./suites/upgrade/giant-x/stress-split-erasure-code/5-workload/ec-rados-default.yaml
  ./suites/upgrade/giant-x/stress-split-erasure-code-x86_64/5-workload/ec-rados-default.yaml

The ec-rados-default.yaml is modified to be a task instead of a
sequential task in a parallel tasks. The ec-rados-sequential.yaml is
added and is linked in
suites/upgrade/giant-x/parallel/2-workload/sequential_run instead of ec-rados-default.yaml.

http://tracker.ceph.com/issues/11221 Fixes: #11221

Signed-off-by: Loic Dachary <loic@dachary.org>