### PR TITLE
calamari_setup fixes

### DIFF
--- a/tasks/calamari_setup.py
+++ b/tasks/calamari_setup.py
@@ -294,7 +294,8 @@ def calamari_install(config, cal_svr):
     elif icetype == 'iso':
         mountpoint = '/mnt/'   # XXX create?
         ret = cal_svr.run(
-            args=['sudo', 'mount', '-r', remote_iceball_file, mountpoint]
+            args=['sudo', 'mount', '-o', 'loop', '-r',
+                  remote_iceball_file, mountpoint]
         )
 
     # install ice_setup package

--- a/tasks/calamari_setup.py
+++ b/tasks/calamari_setup.py
@@ -185,6 +185,8 @@ def calamari_install(config, cal_svr):
 
     test_image = config['test_image']
 
+    if not test_image:
+        raise RuntimeError('Must supply test image')
     log.info('calamari test image: %s' % test_image)
     delete_iceball = False
 


### PR DESCRIPTION
- fix ISO mounting for older distros
- drop the "build the image" code
- simplify configuration: "test_image" points to the path or URL for the image to test
- require that test_image be set
- add a clearer config defaults mechanism
