### PR TITLE
suites/fs: enable directory fragmentation

### DIFF
--- a/suites/fs/basic/dirfrag/frag_enable.yaml
+++ b/suites/fs/basic/dirfrag/frag_enable.yaml
@@ -1,0 +1,10 @@
+
+overrides:
+    ceph:
+        conf:
+        mds:
+            mds bal frag: true
+            mds bal split size: 100
+            mds bal merge size: 5
+            mds bal split bits: 3
+

--- a/suites/fs/multiclient/dirfrag/frag_enable.yaml
+++ b/suites/fs/multiclient/dirfrag/frag_enable.yaml
@@ -1,0 +1,1 @@
+../../basic/dirfrag/frag_enable.yaml

--- a/suites/fs/recovery/dirfrag/frag_enable.yaml
+++ b/suites/fs/recovery/dirfrag/frag_enable.yaml
@@ -1,0 +1,1 @@
+../../basic/dirfrag/frag_enable.yaml

--- a/suites/fs/snaps/dirfrag/frag_enable.yaml
+++ b/suites/fs/snaps/dirfrag/frag_enable.yaml
@@ -1,0 +1,1 @@
+../../basic/dirfrag/frag_enable.yaml

--- a/suites/fs/standbyreplay/dirfrag/frag_enable.yaml
+++ b/suites/fs/standbyreplay/dirfrag/frag_enable.yaml
@@ -1,0 +1,1 @@
+../../basic/dirfrag/frag_enable.yaml

--- a/suites/fs/thrash/dirfrag/frag_enable.yaml
+++ b/suites/fs/thrash/dirfrag/frag_enable.yaml
@@ -1,0 +1,1 @@
+../../basic/dirfrag/frag_enable.yaml

--- a/suites/fs/traceless/dirfrag/frag_enable.yaml
+++ b/suites/fs/traceless/dirfrag/frag_enable.yaml
@@ -1,0 +1,1 @@
+../../basic/dirfrag/frag_enable.yaml

--- a/suites/fs/verify/dirfrag/frag_enable.yaml
+++ b/suites/fs/verify/dirfrag/frag_enable.yaml
@@ -1,0 +1,1 @@
+../../basic/dirfrag/frag_enable.yaml


### PR DESCRIPTION
Setting this in tests globally as a precursor
to enabling it by default in the shipping code.
Set a low mds bal split size in order to make
us hit the fragmentation code more often in
than we usually would in a single MDS environment.

Signed-off-by: John Spray <john.spray@redhat.com>