### PR TITLE
Only use mira and burnupi nodes for ceph-deploy/fs

### DIFF
--- a/suites/ceph-deploy/fs/tasks/cfuse_workunit_suites_blogbench.yaml
+++ b/suites/ceph-deploy/fs/tasks/cfuse_workunit_suites_blogbench.yaml
@@ -1,3 +1,5 @@
+machine_type: mira,burnupi
+
 overrides:
   ceph-deploy:
     conf:

--- a/suites/ceph-deploy/fs/tasks/cfuse_workunit_suites_dbench.yaml
+++ b/suites/ceph-deploy/fs/tasks/cfuse_workunit_suites_dbench.yaml
@@ -1,3 +1,5 @@
+machine_type: mira,burnupi
+
 overrides:
   ceph-deploy:
     conf:

--- a/suites/ceph-deploy/fs/tasks/cfuse_workunit_suites_fsstress.yaml
+++ b/suites/ceph-deploy/fs/tasks/cfuse_workunit_suites_fsstress.yaml
@@ -1,3 +1,5 @@
+machine_type: mira,burnupi
+
 overrides:
   ceph-deploy:
     conf:


### PR DESCRIPTION
The test suite uses 3 OSDs, and specifies an override to test on
separate block devices for OSDs and journal, so we need nodes
that have at least 6 block devices free

Signed-off-by: Travis Rhoden <trhoden@redhat.com>