### PR TITLE
mkfs.btrfs fails with the -f flag on precise, try without it on failure.

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -558,7 +558,19 @@ def cluster(ctx, config):
                         stdout=StringIO(),
                         )
 
-                remote.run(args= ['yes', run.Raw('|')] + ['sudo'] + mkfs + [dev])
+                try:
+                    remote.run(
+                        args=['yes', run.Raw('|')] + ['sudo'] + mkfs + [dev]
+                    )
+                except run.CommandFailedError:
+                    # try again without -f which is not supported on
+                    # older versions of btfs-tools.
+                    log.exception("Trying again without -f...")
+                    mkfs.pop(0)
+                    remote.run(
+                        args=['yes', run.Raw('|')] + ['sudo'] + mkfs + [dev]
+                    )
+
 
                 log.info('mount %s on %s -o %s' % (dev, remote,
                                                    ','.join(mount_options)))


### PR DESCRIPTION
See: http://tracker.ceph.com/issues/11308

This is untested and I'm not entirely sure if it's the correct thing to do, but based on the commit (182cb630346344a6cb3773012d460fc8dfd14285) that changed the original functionality I think it's worth it to try without -f on older distros which might not support that flag.

@gregsfortytwo could you give this branch a try on the tests you've been running to see if it helps?

Signed-off-by: Andrew Schoen <aschoen@redhat.com>