### PR TITLE
task/samba: use SIGTERM to stop samba server

### DIFF
--- a/tasks/samba.py
+++ b/tasks/samba.py
@@ -164,7 +164,7 @@ def task(ctx, config):
         smbd_cmd = [
                 'sudo',
                 'daemon-helper',
-                'kill',
+                'term',
                 'nostdin',
                 '/usr/local/samba/sbin/smbd',
                 '-F',


### PR DESCRIPTION
man samba(8) contains sentences:

To shut down a user's smbd process it is recommended that SIGKILL (-9)
NOT be used, except as a last resort, as this may leave the shared
memory area in an inconsistent state. The safe way to terminate an smbd
is to send it a SIGTERM (-15) signal and wait for it to die on its own.

Signed-off-by: Yan, Zheng <zyan@redhat.com>