### PR TITLE
DNM: tasks: s/pending_create/pending_update/ in MDS

### DIFF
--- a/tasks/mds_journal_repair.py
+++ b/tasks/mds_journal_repair.py
@@ -331,7 +331,7 @@ class TestJournalRepair(CephFSTestCase):
                             "pending_noop": [],
                             "snaps": [],
                             "need_to_purge": {},
-                            "pending_create": [],
+                            "pending_update": [],
                             "pending_destroy": []},
              "result": 0}
         )
@@ -371,7 +371,7 @@ class TestJournalRepair(CephFSTestCase):
                             "pending_noop": [],
                             "snaps": [],
                             "need_to_purge": {},
-                            "pending_create": [],
+                            "pending_update": [],
                             "pending_destroy": []},
              "result": 0}
         )


### PR DESCRIPTION
DNM: don't merge this until https://github.com/ceph/ceph/pull/4282, it's just an update to keep up with that change.

Tests inspecting snapserver dump need updating
to reflect the rename.

Signed-off-by: John Spray <john.spray@redhat.com>