### PR TITLE
task/samba: ignore return code of fuser/losf

### DIFF
--- a/tasks/samba.py
+++ b/tasks/samba.py
@@ -229,6 +229,7 @@ def task(ctx, config):
                         'lsof',
                         backend,
                         ],
+                    check_status=False
                     )
                 remote.run(
                     args=[
@@ -237,6 +238,7 @@ def task(ctx, config):
                         '-M',
                         backend,
                         ],
+                    check_status=False
                     )
             except Exception:
                 log.exception("Saw exception")


### PR DESCRIPTION
if mount point is not used by anyone, both fuser and losf return 1

Fixes: #10624
Signed-off-by: Yan, Zheng <zyan@redhat.com>