### PR TITLE
ceph_manager: Check for exit status 11 from ceph-objectstore-tool import

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -204,7 +204,10 @@ class Thrasher:
             proc = imp_remote.run(args=cmd, wait=True, check_status=False)
             if proc.exitstatus == 10:
                 self.log("Pool went away before processing an import"
-                         "...ignored");
+                         "...ignored")
+            elif proc.exitstatus == 11:
+                self.log("Attempt to import an incompatible export"
+                         "...ignored")
             elif proc.exitstatus:
                 raise Exception("ceph-objectstore-tool: "
                                 "import failure with status {ret}".


### PR DESCRIPTION
Fixes: #11139

Signed-off-by: David Zafman dzafman@redhat.com
(cherry picked from commit 6c5300552d00232d6ecb2c1aa641d515c9d8cd34)

Somehow this was already merged as pull request #394 but a force push must have clobbered it.
