### PR TITLE
suites: log whitelist for journal repair test

### DIFF
--- a/suites/fs/recovery/tasks/journal-repair.yaml
+++ b/suites/fs/recovery/tasks/journal-repair.yaml
@@ -1,4 +1,9 @@
 
+overrides:
+  ceph:
+    log-whitelist:
+      - bad backtrace on dir ino
+
 tasks:
   - cephfs_test_runner:
       modules:


### PR DESCRIPTION
"bad backtrace on dir ino" is emitted because
journaltool's recover-dentries doesn't write
backtraces.

Signed-off-by: John Spray <john.spray@redhat.com>