### PR TITLE
suites/rados: add test for 11429

### DIFF
--- a/suites/rados/singleton-nomsgr/all/11429.yaml
+++ b/suites/rados/singleton-nomsgr/all/11429.yaml
@@ -40,8 +40,8 @@ tasks:
       args: ['toremove']
       kwargs:
         pg_num: 4096
-  - utility.sleep:
-      to_sleep: 30
+  - sleep:
+      duration: 30
   - ceph_manager.wait_for_clean: null
   - radosbench:
       clients: [client.0]
@@ -51,15 +51,15 @@ tasks:
       create_pool: false
   - ceph_manager.remove_pool:
       args: ['toremove']
-  - utility.sleep:
-      to_sleep: 10
+  - sleep:
+      duration: 10
   - ceph.restart:
       daemons:
         - osd.0
         - osd.1
         - osd.2
-  - utility.sleep:
-      to_sleep: 30
+  - sleep:
+      duration: 30
   - ceph_manager.wait_for_clean: null
   - radosbench:
       clients: [client.0]
@@ -74,8 +74,8 @@ tasks:
             args: ['newpool', 'min_size', 2]
         - ceph_manager.set_pool_property:
             args: ['newpool', 'min_size', 1]
-  - utility.sleep:
-      to_sleep: 30
+  - sleep:
+      duration: 30
   - ceph_manager.wait_for_clean: null
   - loop:
       count: 100
@@ -84,11 +84,11 @@ tasks:
             args: ['newpool', 'min_size', 2]
         - ceph_manager.set_pool_property:
             args: ['newpool', 'min_size', 1]
-  - utility.sleep:
-      to_sleep: 30
+  - sleep:
+      duration: 30
   - ceph_manager.wait_for_clean: null
-  - utility.sleep:
-      to_sleep: 30
+  - sleep:
+      duration: 30
   - install.upgrade:
       mon.a: null
   - ceph.restart:
@@ -96,8 +96,8 @@ tasks:
         - osd.0
         - osd.1
         - osd.2
-  - utility.sleep:
-      to_sleep: 30
+  - sleep:
+      duration: 30
   - radosbench:
       clients: [client.0]
       time: 30

--- a/suites/rados/singleton-nomsgr/all/11429.yaml
+++ b/suites/rados/singleton-nomsgr/all/11429.yaml
@@ -1,0 +1,105 @@
+overrides:
+  ceph:
+    conf:
+      mon:
+        debug mon: 20
+        debug ms: 1
+        debug paxos: 20
+        mon warn on legacy crush tunables: false
+        mon min osdmap epochs: 3
+      osd:
+        osd map cache size: 2
+        osd map max advance: 1
+        debug filestore: 20
+        debug journal: 20
+        debug ms: 1
+        debug osd: 20
+    log-whitelist:
+    - osd_map_cache_size
+    - slow request
+    - scrub mismatch
+    - ScrubResult
+roles:
+- - mon.a
+  - mds.a
+  - osd.0
+  - osd.1
+  - mon.b
+  - mon.c
+  - osd.2
+  - client.0
+tasks:
+- install:
+    branch: v0.80.8
+- print: '**** done installing firefly'
+- ceph:
+    fs: xfs
+- print: '**** done ceph'
+- full_sequential:
+  - ceph_manager.create_pool:
+      args: ['toremove']
+      kwargs:
+        pg_num: 4096
+  - utility.sleep:
+      to_sleep: 30
+  - ceph_manager.wait_for_clean: null
+  - radosbench:
+      clients: [client.0]
+      time: 120
+      size: 1
+      pool: toremove
+      create_pool: false
+  - ceph_manager.remove_pool:
+      args: ['toremove']
+  - utility.sleep:
+      to_sleep: 10
+  - ceph.restart:
+      daemons:
+        - osd.0
+        - osd.1
+        - osd.2
+  - utility.sleep:
+      to_sleep: 30
+  - ceph_manager.wait_for_clean: null
+  - radosbench:
+      clients: [client.0]
+      time: 60
+      size: 1
+  - ceph_manager.create_pool:
+      args: ['newpool']
+  - loop:
+      count: 100
+      body:
+        - ceph_manager.set_pool_property:
+            args: ['newpool', 'min_size', 2]
+        - ceph_manager.set_pool_property:
+            args: ['newpool', 'min_size', 1]
+  - utility.sleep:
+      to_sleep: 30
+  - ceph_manager.wait_for_clean: null
+  - loop:
+      count: 100
+      body:
+        - ceph_manager.set_pool_property:
+            args: ['newpool', 'min_size', 2]
+        - ceph_manager.set_pool_property:
+            args: ['newpool', 'min_size', 1]
+  - utility.sleep:
+      to_sleep: 30
+  - ceph_manager.wait_for_clean: null
+  - utility.sleep:
+      to_sleep: 30
+  - install.upgrade:
+      mon.a: null
+  - ceph.restart:
+      daemons:
+        - osd.0
+        - osd.1
+        - osd.2
+  - utility.sleep:
+      to_sleep: 30
+  - radosbench:
+      clients: [client.0]
+      time: 30
+      size: 1
+  - ceph_manager.wait_for_clean: null

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -1902,3 +1902,20 @@ class CephManager:
         Return path to osd data with {id} needing to be replaced
         """
         return "/var/lib/ceph/osd/ceph-{id}"
+
+def utility_task(name):
+    def task(ctx, config):
+        if config is None:
+            config = {}
+        args = config.get('args', [])
+        kwargs = config.get('kwargs', {})
+        fn = getattr(ctx.manager, name)
+        fn(*args, **kwargs)
+    return task
+
+revive_osd = utility_task("revive_osd")
+kill_osd = utility_task("kill_osd")
+create_pool = utility_task("create_pool")
+remove_pool = utility_task("remove_pool")
+wait_for_clean = utility_task("wait_for_clean")
+set_pool_property = utility_task("set_pool_property")

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -1904,6 +1904,10 @@ class CephManager:
         return "/var/lib/ceph/osd/ceph-{id}"
 
 def utility_task(name):
+    """
+    Generate ceph_manager subtask corresponding to ceph_manager
+    method name
+    """
     def task(ctx, config):
         if config is None:
             config = {}

--- a/tasks/radosbench.py
+++ b/tasks/radosbench.py
@@ -64,7 +64,7 @@ def task(ctx, config):
         if config.get('create_pool', True):
             if config.get('pool'):
                 pool = config.get('pool')
-                if pool is not 'data':
+                if pool != 'data':
                     ctx.manager.create_pool(pool, erasure_code_profile_name=profile_name)
             else:
                 pool = ctx.manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)

--- a/tasks/radosbench.py
+++ b/tasks/radosbench.py
@@ -20,8 +20,10 @@ def task(ctx, config):
         clients: [client list]
         time: <seconds to run>
         pool: <pool to use>
+        size: write size to use
         unique_pool: use a unique pool, defaults to False
         ec_pool: create an ec pool, defaults to False
+        create_pool: create pool, defaults to False
         erasure_code_profile:
           name: teuthologyprofile
           k: 2
@@ -59,12 +61,13 @@ def task(ctx, config):
             profile_name = None
 
         pool = 'data'
-        if config.get('pool'):
-            pool = config.get('pool')
-            if pool is not 'data':
-                ctx.manager.create_pool(pool, erasure_code_profile_name=profile_name)
-        else:
-            pool = ctx.manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)
+        if config.get('create_pool', True):
+            if config.get('pool'):
+                pool = config.get('pool')
+                if pool is not 'data':
+                    ctx.manager.create_pool(pool, erasure_code_profile_name=profile_name)
+            else:
+                pool = ctx.manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)
 
         proc = remote.run(
             args=[
@@ -75,6 +78,7 @@ def task(ctx, config):
                           'rados',
 			  '--no-log-to-stderr',
                           '--name', role,
+                          '-b', str(config.get('size', 4<<20)),
                           '-p' , pool,
                           'bench', str(config.get('time', 360)), 'write',
                           ]).format(tdir=testdir),

--- a/tasks/utility.py
+++ b/tasks/utility.py
@@ -1,0 +1,9 @@
+import logging
+import time
+
+log = logging.getLogger(__name__)
+
+def sleep(ctx, config):
+    to_sleep = config.get("to_sleep", 5)
+    log.info("Sleeping for {to_sleep}".format(to_sleep=to_sleep))
+    time.sleep(to_sleep)

--- a/tasks/utility.py
+++ b/tasks/utility.py
@@ -1,9 +1,0 @@
-import logging
-import time
-
-log = logging.getLogger(__name__)
-
-def sleep(ctx, config):
-    to_sleep = config.get("to_sleep", 5)
-    log.info("Sleeping for {to_sleep}".format(to_sleep=to_sleep))
-    time.sleep(to_sleep)


### PR DESCRIPTION
This patch also adds some convenience facilities for making
some of the ceph_manager methods into tasks usable from a
yaml file.

Signed-off-by: Samuel Just <sjust@redhat.com>