### PR TITLE
suites/fs: add another log whitelist to journal-repair

### DIFF
--- a/suites/fs/recovery/tasks/journal-repair.yaml
+++ b/suites/fs/recovery/tasks/journal-repair.yaml
@@ -3,6 +3,7 @@ overrides:
   ceph:
     log-whitelist:
       - bad backtrace on dir ino
+      - error reading table object
 
 tasks:
   - cephfs_test_runner:


### PR DESCRIPTION
This is the table unreadable error for mds1_inotable that
we get when trying to start an MDS whose objects are gone.

Signed-off-by: John Spray <john.spray@redhat.com>