### PR TITLE
ensure summary is looked for the user we need (part 2)

### DIFF
--- a/tasks/radosgw_admin.py
+++ b/tasks/radosgw_admin.py
@@ -21,19 +21,9 @@ import boto.s3.acl
 import util.rgw as rgw_utils
 
 from teuthology import misc as teuthology
-from util.rgw import rgwadmin
+from util.rgw import rgwadmin, get_user_summary, get_user_successful_ops
 
 log = logging.getLogger(__name__)
-
-
-def successful_ops(out):
-    """Extract total from the first summary entry (presumed to be only one)"""
-    summary = out['summary']
-    if len(summary) == 0:
-        return 0
-    entry = summary[0]
-    return entry['total']['successful_ops']
-
 
 def get_acl(key):
     """
@@ -793,7 +783,7 @@ def task(ctx, config):
     timestamp = time.time()
     while time.time() - timestamp <= (20 * 60):      # wait up to 20 minutes
         (err, out) = rgwadmin(ctx, client, ['usage', 'show', '--categories', 'delete_obj'])  # last operation we did is delete obj, wait for it to flush
-        if successful_ops(out) > 0:
+        if get_user_successful_ops(out, user1) > 0:
             break
         time.sleep(1)
 
@@ -804,14 +794,7 @@ def task(ctx, config):
     assert len(out['entries']) > 0
     assert len(out['summary']) > 0
 
-    # find summary for user1
-    user_summary = None
-    for summary in out['summary']:
-        if summary.get('user') == user1:
-            user_summary = summary
-
-    if not user_summary:
-        raise AssertionError('No summary info found for user: %s' % user1)
+    user_summary = get_user_summary(out, user1)
 
     total = user_summary['total']
     assert total['successful_ops'] > 0

--- a/tasks/util/rgw.py
+++ b/tasks/util/rgw.py
@@ -49,6 +49,24 @@ def rgwadmin(ctx, client, cmd, stdin=StringIO(), check_status=False):
             log.info(' raw result: %s' % j)
     return (r, j)
 
+def get_user_summary(out, user):
+    """Extract the summary for a given user"""
+    user_summary = None
+    for summary in out['summary']:
+        if summary.get('user') == user:
+            user_summary = summary
+
+    if not user_summary:
+        raise AssertionError('No summary info found for user: %s' % user)
+
+    return user_summary
+
+def get_user_successful_ops(out, user):
+    summary = out['summary']
+    if len(summary) == 0:
+        return 0
+    return get_user_summary(out, user)['total']['successful_ops']
+
 def get_zone_host_and_port(ctx, client, zone):
     _, region_map = rgwadmin(ctx, client, check_status=True,
                              cmd=['-n', client, 'region-map', 'get'])


### PR DESCRIPTION
Move the get_user_summary(out, user) logic to util.rgw so that it can be
shared between radosgw_admin_rest.py and radosgw_admin.py and modify
them accordingly.

http://tracker.ceph.com/issues/11180 Fixes: #11180

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit 97e6d808f086834f2350084d5de36be285ad2bde)

Conflicts:
	tasks/radosgw_admin.py
        the context around def successful_ops(out): changed but is
	unrelated to the modification