### PR TITLE
Reduce fs test node usage

### DIFF
--- a/clusters/fixed-2-ucephfs.yaml
+++ b/clusters/fixed-2-ucephfs.yaml
@@ -1,0 +1,3 @@
+roles:
+- [mon.a, mds.a, osd.0, osd.1, client.0]
+- [mon.b, mds.a-s, mon.c, osd.2, osd.3]

--- a/suites/fs/basic/clusters/fixed-2-ucephfs.yaml
+++ b/suites/fs/basic/clusters/fixed-2-ucephfs.yaml
@@ -1,0 +1,1 @@
+../../../../clusters/fixed-2-ucephfs.yaml

--- a/suites/fs/basic/clusters/fixed-3-cephfs.yaml
+++ b/suites/fs/basic/clusters/fixed-3-cephfs.yaml
@@ -1,1 +1,0 @@
-../../../../clusters/fixed-3-cephfs.yaml

--- a/suites/fs/snaps/clusters/fixed-2-ucephfs.yaml
+++ b/suites/fs/snaps/clusters/fixed-2-ucephfs.yaml
@@ -1,0 +1,1 @@
+../../../../clusters/fixed-2-ucephfs.yaml

--- a/suites/fs/snaps/clusters/fixed-3-cephfs.yaml
+++ b/suites/fs/snaps/clusters/fixed-3-cephfs.yaml
@@ -1,1 +1,0 @@
-../../../../clusters/fixed-3-cephfs.yaml

--- a/suites/fs/standbyreplay/clusters/standby-replay.yaml
+++ b/suites/fs/standbyreplay/clusters/standby-replay.yaml
@@ -6,6 +6,5 @@ overrides:
                 mds standby replay: true
 
 roles:
-- [mon.a, mds.a, mds.b-s-0, osd.0, osd.1]
+- [mon.a, mds.a, mds.b-s-0, osd.0, osd.1, client.0]
 - [mon.b, mds.c-s-0, mds.d-s-0, mon.c, osd.2, osd.3]
-- [client.0]

--- a/suites/fs/thrash/clusters/mds-1active-1standby.yaml
+++ b/suites/fs/thrash/clusters/mds-1active-1standby.yaml
@@ -1,4 +1,3 @@
 roles:
-- [mon.a, mon.c, osd.0, osd.1, osd.2]
-- [mon.b, mds.a, osd.3, osd.4, osd.5]
-- [client.0, mds.b-s-a]
+- [mon.a, mon.c, osd.0, osd.1, osd.2, mds.b-s-a]
+- [mon.b, mds.a, osd.3, osd.4, osd.5, client.0]

--- a/suites/fs/traceless/clusters/fixed-2-ucephfs.yaml
+++ b/suites/fs/traceless/clusters/fixed-2-ucephfs.yaml
@@ -1,0 +1,1 @@
+../../../../clusters/fixed-2-ucephfs.yaml

--- a/suites/fs/traceless/clusters/fixed-3-cephfs.yaml
+++ b/suites/fs/traceless/clusters/fixed-3-cephfs.yaml
@@ -1,1 +1,0 @@
-../../../../clusters/fixed-3-cephfs.yaml

--- a/suites/fs/verify/clusters/fixed-2-ucephfs.yaml
+++ b/suites/fs/verify/clusters/fixed-2-ucephfs.yaml
@@ -1,0 +1,1 @@
+../../../../clusters/fixed-2-ucephfs.yaml

--- a/suites/fs/verify/clusters/fixed-3-cephfs.yaml
+++ b/suites/fs/verify/clusters/fixed-3-cephfs.yaml
@@ -1,1 +1,0 @@
-../../../../clusters/fixed-3-cephfs.yaml

--- a/suites/multimds/libcephfs/clusters/3-mds.yaml
+++ b/suites/multimds/libcephfs/clusters/3-mds.yaml
@@ -1,4 +1,4 @@
 roles:
 - [mon.a, mon.c, mds.a, osd.0, osd.1, osd.2]
-- [mon.b, mds.b, mds.c, osd.3, osd.4, osd.5]
-- [client.0]
+- [mon.b, mds.b, mds.c, osd.3, osd.4, osd.5, client.0]
+

--- a/suites/multimds/libcephfs/clusters/9-mds.yaml
+++ b/suites/multimds/libcephfs/clusters/9-mds.yaml
@@ -1,4 +1,3 @@
 roles:
 - [mon.a, mon.c, mds.a, mds.b, mds.c, mds.d, osd.0, osd.1, osd.2]
-- [mon.b, mds.e, mds.f, mds.g, mds.h, mds.i, osd.3, osd.4, osd.5]
-- [client.0]
+- [mon.b, mds.e, mds.f, mds.g, mds.h, mds.i, osd.3, osd.4, osd.5, client.0]

--- a/suites/multimds/verify/clusters/3-mds.yaml
+++ b/suites/multimds/verify/clusters/3-mds.yaml
@@ -1,4 +1,3 @@
 roles:
 - [mon.a, mon.c, mds.a, osd.0, osd.1, osd.2]
-- [mon.b, mds.b, mds.c, osd.3, osd.4, osd.5]
-- [client.0]
+- [mon.b, mds.b, mds.c, osd.3, osd.4, osd.5, client.0]

--- a/suites/multimds/verify/clusters/9-mds.yaml
+++ b/suites/multimds/verify/clusters/9-mds.yaml
@@ -1,4 +1,3 @@
 roles:
 - [mon.a, mon.c, mds.a, mds.b, mds.c, mds.d, osd.0, osd.1, osd.2]
-- [mon.b, mds.e, mds.f, mds.g, mds.h, mds.i, osd.3, osd.4, osd.5]
-- [client.0]
+- [mon.b, mds.e, mds.f, mds.g, mds.h, mds.i, osd.3, osd.4, osd.5, client.0]


### PR DESCRIPTION
This reconfigures the cluster yaml fragments for most of the filesystem-related tests to reduce the number of nodes they use.