### PR TITLE
erasure-code: lrc plugin workload

### DIFF
--- a/erasure-code/ec-rados-plugin=lrc-k=4-m=2-l=3.yaml
+++ b/erasure-code/ec-rados-plugin=lrc-k=4-m=2-l=3.yaml
@@ -1,7 +1,7 @@
 tasks:
 - rados:
     clients: [client.0]
-    ops: 4000
+    ops: 400
     objects: 50
     ec_pool: true
     erasure_code_profile:

--- a/suites/rados/thrash-erasure-code-big/cluster/12-osds.yaml
+++ b/suites/rados/thrash-erasure-code-big/cluster/12-osds.yaml
@@ -1,0 +1,5 @@
+roles:
+- [osd.0, osd.1, osd.2, client.0, mon.a]
+- [osd.3, osd.4, osd.5, mon.b]
+- [osd.6, osd.7, osd.8, mon.c]
+- [osd.9, osd.10, osd.11]

--- a/suites/rados/thrash-erasure-code-big/fs
+++ b/suites/rados/thrash-erasure-code-big/fs
@@ -1,0 +1,1 @@
+../thrash/fs

--- a/suites/rados/thrash-erasure-code-big/msgr-failures
+++ b/suites/rados/thrash-erasure-code-big/msgr-failures
@@ -1,0 +1,1 @@
+../thrash/msgr-failures

--- a/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
+++ b/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
@@ -1,0 +1,18 @@
+tasks:
+- install:
+- ceph:
+    log-whitelist:
+    - wrongly marked me down
+    - objects unfound and apparently lost
+    - slow request
+    conf:
+      osd:
+        osd debug reject backfill probability: .3
+        osd max backfills: 1
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+- thrashosds:
+    timeout: 1200
+    chance_pgnum_grow: 1
+    chance_pgpnum_fix: 1
+    min_in: 8

--- a/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
+++ b/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
@@ -1,0 +1,22 @@
+overrides:
+  ceph:
+    conf:
+      mon:
+        mon min osdmap epochs: 2
+      osd:
+        osd map cache size: 1
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+tasks:
+- install:
+- ceph:
+    log-whitelist:
+    - wrongly marked me down
+    - objects unfound and apparently lost
+    - osd_map_cache_size
+- thrashosds:
+    timeout: 1800
+    chance_pgnum_grow: 1
+    chance_pgpnum_fix: 1
+    chance_test_map_discontinuity: 0.5
+    min_in: 8

--- a/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
+++ b/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
@@ -1,0 +1,16 @@
+tasks:
+- install:
+- ceph:
+    conf:
+      osd:
+        osd max backfills: 1
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+    log-whitelist:
+    - wrongly marked me down
+    - objects unfound and apparently lost
+- thrashosds:
+    timeout: 1200
+    chance_pgnum_grow: 3
+    chance_pgpnum_fix: 1
+    min_in: 8

--- a/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
+++ b/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
@@ -1,0 +1,15 @@
+tasks:
+- install:
+- ceph:
+    log-whitelist:
+    - wrongly marked me down
+    - objects unfound and apparently lost
+    conf:
+      osd:
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+- thrashosds:
+    timeout: 1200
+    chance_pgnum_grow: 2
+    chance_pgpnum_fix: 1
+    min_in: 8

--- a/suites/rados/thrash-erasure-code-big/workloads/ec-rados-plugin=lrc-k=4-m=2-l=3.yaml
+++ b/suites/rados/thrash-erasure-code-big/workloads/ec-rados-plugin=lrc-k=4-m=2-l=3.yaml
@@ -1,0 +1,1 @@
+../../../../erasure-code/ec-rados-plugin=lrc-k=4-m=2-l=3.yaml


### PR DESCRIPTION
Add a workload that uses the lrc erasure code plugin. Instead of adding
it to suites/rados/thrash-erasure-code/workloads, a new suite is created
at suites/rados/thrash-erasure-code-big because it needs more OSDs than
other erasure code plugins. The alternative would be to increase the
number of OSDs for all erasure code plugins, but that would needlessly
increase the resources requirements.

 * cluster/12-osds.yaml creates a 12 OSDs, 3 MONs cluster

 * thrash-erasure-code-big/thrashers/*.yaml are the same as
   thrash-erasure-code/thrashers/*.yaml except they require that at
   least 8 OSDs are in at all times (instead of 4) because lrc PGs with
   k=4, m=2, l=3 are undersized if they do not have 8 OSDs. It is
   possible that crush fails to map 8 OSDs when only 8 OSDs are
   available, but that must not disturb the workload because min_size is
   4.

http://tracker.ceph.com/issues/11666 Fixes: #11666

Signed-off-by: Loic Dachary <ldachary@redhat.com>