### PR TITLE
Logrotate

### DIFF
--- a/clusters/fixed-2-ucephfs.yaml
+++ b/clusters/fixed-2-ucephfs.yaml
@@ -1,3 +1,6 @@
 roles:
 - [mon.a, mds.a, osd.0, osd.1, client.0]
 - [mon.b, mds.a-s, mon.c, osd.2, osd.3]
+log-rotate:
+  ceph-mds: 10G
+  ceph-osd: 10G

--- a/clusters/fixed-3-cephfs.yaml
+++ b/clusters/fixed-3-cephfs.yaml
@@ -2,3 +2,6 @@ roles:
 - [mon.a, mds.a, osd.0, osd.1]
 - [mon.b, mds.a-s, mon.c, osd.2, osd.3]
 - [client.0]
+log-rotate:
+  ceph-mds: 10G
+  ceph-osd: 10G

--- a/suites/fs/multiclient/clusters/three_clients.yaml
+++ b/suites/fs/multiclient/clusters/three_clients.yaml
@@ -3,3 +3,8 @@ roles:
 - [client.2]
 - [client.1]
 - [client.0]
+
+log-rotate:
+  ceph-mds: 10G
+  ceph-osd: 10G
+

--- a/suites/fs/multiclient/clusters/two_clients.yaml
+++ b/suites/fs/multiclient/clusters/two_clients.yaml
@@ -2,3 +2,8 @@ roles:
 - [mon.a, mon.b, mon.c, mds.a, osd.0, osd.1, osd.2]
 - [client.1]
 - [client.0]
+
+log-rotate:
+  ceph-mds: 10G
+  ceph-osd: 10G
+

--- a/suites/fs/recovery/clusters/2-remote-clients.yaml
+++ b/suites/fs/recovery/clusters/2-remote-clients.yaml
@@ -1,3 +1,6 @@
 roles:
 - [mon.a, osd.0, mds.a, mds.b, client.1]
 - [client.0, osd.1, osd.2]
+log-rotate:
+  ceph-mds: 10G
+  ceph-osd: 10G

--- a/suites/fs/standbyreplay/clusters/standby-replay.yaml
+++ b/suites/fs/standbyreplay/clusters/standby-replay.yaml
@@ -8,3 +8,6 @@ overrides:
 roles:
 - [mon.a, mds.a, mds.b-s-0, osd.0, osd.1, client.0]
 - [mon.b, mds.c-s-0, mds.d-s-0, mon.c, osd.2, osd.3]
+log-rotate:
+  ceph-mds: 10G
+  ceph-osd: 10G

--- a/suites/fs/thrash/clusters/mds-1active-1standby.yaml
+++ b/suites/fs/thrash/clusters/mds-1active-1standby.yaml
@@ -1,3 +1,6 @@
 roles:
 - [mon.a, mon.c, osd.0, osd.1, osd.2, mds.b-s-a]
 - [mon.b, mds.a, osd.3, osd.4, osd.5, client.0]
+log-rotate:
+  ceph-mds: 10G
+  ceph-osd: 10G

--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -72,13 +72,13 @@ def ceph_log(ctx, config):
             )
         )
 
-    class Rotater:
-        stopping = False
+    class Rotater(object):
+        stop_event = gevent.event.Event()
         def invoke_logrotate(self):
             #1) install ceph-test.conf in /etc/logrotate.d
             #2) continuously loop over logrotate invocation with ceph-test.conf
-            while not self.stopping:
-                time.sleep(30)
+            while not self.stop_event.is_set():
+                self.stop_event.wait(timeout=30)
                 run.wait(
                     ctx.cluster.run(
                         args=['sudo', 'logrotate', '/etc/logrotate.d/ceph-test.conf'

--- a/tasks/logrotate.conf
+++ b/tasks/logrotate.conf
@@ -1,11 +1,13 @@
-/var/log/ceph/*mds*.log {
+/var/log/ceph/*{daemon_type}*.log {{
     rotate 100
-    size 1M
+    size {max_size}
     compress
     sharedscripts
     postrotate
-        killall ceph-mds -1 || true
+        killall {daemon_type} -1 || true
     endscript
     missingok
     notifempty
-}
+    su root root
+}}
+

--- a/tasks/logrotate.conf
+++ b/tasks/logrotate.conf
@@ -1,0 +1,11 @@
+/var/log/ceph/*mds*.log {
+    rotate 100
+    size 1M
+    compress
+    sharedscripts
+    postrotate
+        killall ceph-mds -1 || true
+    endscript
+    missingok
+    notifempty
+}


### PR DESCRIPTION
This PR currently includes log rotation in the Ceph task that you can configure via yaml. It works in the small set of tests I've run against it, but is not yet enabled anywhere by default and shouldn't be merged.

I'm testing it against an FS run and will update the PR with config changes for that once it passes.