### PR TITLE
tasks/cephfs: time out on ceph-fuses that don't die

### DIFF
--- a/tasks/cephfs/fuse_mount.py
+++ b/tasks/cephfs/fuse_mount.py
@@ -236,7 +236,7 @@ class FuseMount(CephFSMount):
         try:
             if self.fuse_daemon:
                 # Permit a timeout, so that we do not block forever
-                run.wait([self.fuse_daemon], 30)
+                run.wait([self.fuse_daemon], 900)
         except MaxWhileTries:
             log.error("process failed to terminate after unmount.  This probably"
                       "indicates a bug within ceph-fuse.")


### PR DESCRIPTION
For cases where we have e.g. poked the fuse abort
file for a process, but it's still not dying.  Because
this is a special class of error (unlike e.g. when
we force umount something because the network is gone)
raise the error instead of trying again to kill
the client.

Fixes: #11835
Signed-off-by: John Spray <john.spray@redhat.com>