### PR TITLE
Single node ceph-deploy tests to exercise commonly used cli

### DIFF
--- a/suites/smoke/1node/clusters/fixed-1.yaml
+++ b/suites/smoke/1node/clusters/fixed-1.yaml
@@ -1,0 +1,1 @@
+../../../../clusters/fixed-1.yaml

--- a/suites/smoke/1node/tasks/ceph-deploy.yaml
+++ b/suites/smoke/1node/tasks/ceph-deploy.yaml
@@ -1,0 +1,2 @@
+tasks:
+- ceph_deploy.single_node_test: null


### PR DESCRIPTION
Single Node Ceph-deploy tests to exercise commonly used CLI and test basic init startup
  - Need to add 1 node yaml for this test in smoke suite

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>