### PR TITLE
add the log object to ceph_manager

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -6,12 +6,14 @@ import random
 import time
 import gevent
 import json
+import logging
 import threading
 import os
 from teuthology import misc as teuthology
 from tasks.scrub import Scrubber
 from teuthology.orchestra.remote import Remote
-import subprocess
+
+log = logging.getLogger(__name__)
 
 def make_admin_daemon_dir(ctx, remote):
     """


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>
(cherry picked from commit f7c1ca4a1e23b03ecf86d5e67d563f95b3a82f99)

Conflicts:
	tasks/ceph_manager.py
	lines shifted but nothing significant changed