### PR TITLE
client-upgrade: temporarily use pre-backport hammer branch

### DIFF
--- a/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_api_tests.yaml
+++ b/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_api_tests.yaml
@@ -1,6 +1,6 @@
 tasks:
 - workunit:
-    branch: hammer
+    branch: wip-12109-hammer
     clients:
       client.0:
         - rbd/test_librbd_api.sh

--- a/suites/upgrade/client-upgrade/hammer-client-x/rbd/2-workload/rbd_notification_tests.yaml
+++ b/suites/upgrade/client-upgrade/hammer-client-x/rbd/2-workload/rbd_notification_tests.yaml
@@ -1,6 +1,6 @@
 tasks:
 - workunit:
-    branch: hammer
+    branch: wip-12109-hammer
     clients:
       client.0:
         - rbd/notify_master.sh
@@ -10,7 +10,7 @@ tasks:
       RBD_FEATURES: "13"
 - print: "**** done rbd: old librbd -> new librbd"
 - workunit:
-    branch: hammer
+    branch: wip-12109-hammer
     clients:
       client.0:
         - rbd/notify_slave.sh


### PR DESCRIPTION
Until the client-upgrade scripts are backported to hammer, the
tests should use the temporary branch from PR 5046. Once a new
hammer version is released that includes these test scripts,
this commit can be reverted (since the wip branch will be deleted).

Signed-off-by: Jason Dillaman <dillaman@redhat.com>