### PR TITLE
Add a test case to turn on the feature flag to read all replicas for EC pool

### DIFF
--- a/suites/rados/thrash-erasure-code/thrashers/subreadall.yaml
+++ b/suites/rados/thrash-erasure-code/thrashers/subreadall.yaml
@@ -1,0 +1,18 @@
+tasks:
+- install:
+- ceph:
+    log-whitelist:
+    - wrongly marked me down
+    - objects unfound and apparently lost
+    conf:
+      osd:
+        osd debug reject backfill probability: .3
+        osd max backfills: 1
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+        osd pool erasure code subread all: true
+- thrashosds:
+    timeout: 1200
+    chance_pgnum_grow: 1
+    chance_pgpnum_fix: 1
+    min_in: 4


### PR DESCRIPTION
This test is to cover the following feature:
   osd_pool_erasure_code_subread_all

Signed-off-by: Guang Yang <yguang@yahoo-inc.com>