### PR TITLE
cephfs/test_auto_repair.py: flush journal after umount

### DIFF
--- a/tasks/cephfs/test_auto_repair.py
+++ b/tasks/cephfs/test_auto_repair.py
@@ -37,11 +37,12 @@ class TestMDSAutoRepair(CephFSTestCase):
         # create more files in another directory. make sure MDS trim dentries in testdir1
         self.mount_a.run_shell(["sudo", "bash", "-c", create_script.format("testdir2")])
 
+        # drop inodes caps
+        self.mount_a.umount_wait()
+
         # flush journal entries to dirfrag objects
         self.fs.mds_asok(['flush', 'journal'])
 
-        # drop inodes caps
-        self.mount_a.umount_wait()
         self.mount_a.mount()
         self.mount_a.wait_until_mounted()
 


### PR DESCRIPTION
When client capabilities get released, MDS may update corresponding
inodes' client writable range and mark those inodes dirty. The auto
repair test expects MDS to trim inodes from its cache, but MDS can't
trim dirty inodes. So we should flush journal after umount.

Fixes: #12172
Signed-off-by: Yan, Zheng <zyan@redhat.com>
(cherry picked from commit 835ad8b8f3038290846c612b66f3bffcc5755338)