### PR TITLE
rgw: do not enable both tcp and uds for fastcgi

### DIFF
--- a/tasks/rgw.py
+++ b/tasks/rgw.py
@@ -249,8 +249,6 @@ def start_rgw(ctx, config):
                         tdir=testdir,
                         client=client,
                         ),
-                    '--rgw-frontends',
-                    'fastcgi socket_port=9000 socket_host=0.0.0.0',
                 ])
             else:
                 # for mod_proxy_fcgi, using tcp


### PR DESCRIPTION
This fixes a bug where we were setting up mod_fastcgi to use both tcp
and uds.