### PR TITLE
added optional YAML parameters to use chef from different repos

### DIFF
--- a/tasks/chef.py
+++ b/tasks/chef.py
@@ -11,9 +11,23 @@ log = logging.getLogger(__name__)
 def task(ctx, config):
     """
     Run chef-solo on all nodes.
+
+    Optional parameters:
+    tasks:
+    -chef
+        script_url: # override default location for solo-from-scratch for Chef
+        chef_repo: # override default Chef repo used by solo-from-scratch
+        chef_branch: # to choose a different upstream branch for ceph-qa-chef
     """
     log.info('Running chef-solo...')
 
+    if config is None:
+        config = {}
+
+    assert isinstance(config, dict), "chef - need config"
+    chef_script = config.get('script_url', 'http://ceph.com/git/?p=ceph-qa-chef.git;a=blob_plain;f=solo/solo-from-scratch;hb=HEAD')
+    chef_repo = config.get('chef_repo', "")
+    chef_branch = config.get('chef_branch', "")
     run.wait(
         ctx.cluster.run(
             args=[
@@ -21,8 +35,10 @@ def task(ctx, config):
 #                '-q',
                 '-O-',
 #                'https://raw.github.com/ceph/ceph-qa-chef/master/solo/solo-from-scratch',
-                'http://git.ceph.com/?p=ceph-qa-chef.git;a=blob_plain;f=solo/solo-from-scratch;hb=HEAD',
+                chef_script,
                 run.Raw('|'),
+                run.Raw('CHEF_REPO={repo}'.format(repo=chef_repo)),
+                run.Raw('CHEF_BRANCH={branch}'.format(branch=chef_branch)),
                 'sh',
                 '-x',
                 ],


### PR DESCRIPTION

These variables are needed because ceph-qa-suite bootstraps ceph-qa-chef via
http download of solo-from/scratch/run. This adds a variable to override the
default script. 

variables added
======
tasks:
-chef
  script_url: # override default location for solo-from-scratch for Chef
  chef_repo: # override default Chef repo used by solo-from-scratch
  chef_branch: # to choose a different git upstream branch for ceph-qa-chef

Signed-off-by: Douglas Fuller <dfuller@redhat.com>
(cherry picked from commit 7b855dea090570196ae8fd55616d9071425ddcb9)

Conflicts:
	tasks/chef.py : trivial conflict ceph.com/git => git.ceph.com
	tasks/rbd.py : discard the patch, only chef.py is of interest