### PR TITLE
Removed rhel* configurations with a goal that they will be covered in…

### DIFF
--- a/distros/supported/rhel_6.4.yaml
+++ b/distros/supported/rhel_6.4.yaml
@@ -1,1 +1,0 @@
-../all/rhel_6.4.yaml

--- a/distros/supported/rhel_6.5.yaml
+++ b/distros/supported/rhel_6.5.yaml
@@ -1,1 +1,0 @@
-../all/rhel_6.5.yaml

--- a/distros/supported/rhel_7.0.yaml
+++ b/distros/supported/rhel_7.0.yaml
@@ -1,1 +1,0 @@
-../all/rhel_7.0.yaml


### PR DESCRIPTION
… the Octo lab

and won't be used by vps runs in Sepia lab

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>