### PR TITLE
3-size-2-min-size: keep 4 in during thrashing

### DIFF
--- a/overrides/3-size-2-min-size.yaml
+++ b/overrides/3-size-2-min-size.yaml
@@ -1,4 +1,6 @@
 overrides:
+  thrashosds:
+    min_in: 4
   ceph:
     conf:
       global:


### PR DESCRIPTION
Workaround for 12231.

Fixes: #12231
Signed-off-by: Samuel Just <sjust@redhat.com>