### PR TITLE
increase fuse mount timeout to 300 seconds

### DIFF
--- a/tasks/cephfs/fuse_mount.py
+++ b/tasks/cephfs/fuse_mount.py
@@ -97,7 +97,7 @@ class FuseMount(CephFSMount):
         while list_connections() == pre_mount_conns:
             time.sleep(1)
             waited += 1
-            if waited > 30:
+            if waited > 300:
                 raise RuntimeError("Fuse mount failed to populate /sys/ after {0} seconds".format(
                     waited
                 ))


### PR DESCRIPTION
The 30 seconds value is too conservative when running on virtual
machines because they tend to be slow. The timeout is useful to avoid
blocking forever, but it can be as long as 5 minutes without creating
any actual problem.

Signed-off-by: Loic Dachary <loic@dachary.org>