### PR TITLE
Changed s3tests ref to firefly

### DIFF
--- a/suites/upgrade/hammer/newer/2-workload/s3tests.yaml
+++ b/suites/upgrade/hammer/newer/2-workload/s3tests.yaml
@@ -4,6 +4,6 @@ workload:
   - print: "**** done rgw: [client.0] 2-workload"
   - s3tests:
       client.0:
-        force-branch: firefly-original
+        force-branch: firefly
         rgw_server: client.0
   - print: "**** done s3tests 2-workload"


### PR DESCRIPTION
Per IRC chat by Yehuda, Josh and Dan:

"the purpose of firefly-original in general was for upgrades from prior point releases of firefly, where newer tests on the firefly branch would fail
it shouldn't be used if it's just a firefly->hammer upgrade though, the plain old firefly branch should be fine for that"

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>