### PR TITLE
rados suite: add resources requirements hints

### DIFF
--- a/erasure-code/ec-rados-plugin=jerasure-k=2-m=1.yaml
+++ b/erasure-code/ec-rados-plugin=jerasure-k=2-m=1.yaml
@@ -22,3 +22,11 @@ tasks:
       copy_from: 50
       setattr: 25
       rmattr: 25
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/erasure-code/ec-rados-plugin=jerasure-k=3-m=1.yaml
+++ b/erasure-code/ec-rados-plugin=jerasure-k=3-m=1.yaml
@@ -28,3 +28,11 @@ tasks:
       copy_from: 50
       setattr: 25
       rmattr: 25
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/basic/tasks/rados_api_tests.yaml
+++ b/suites/rados/basic/tasks/rados_api_tests.yaml
@@ -12,3 +12,11 @@ tasks:
         - rados/test.sh
         - rados/test_pool_quota.sh
 
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/basic/tasks/rados_python.yaml
+++ b/suites/rados/basic/tasks/rados_python.yaml
@@ -7,3 +7,11 @@ tasks:
     clients:
       client.0:
         - rados/test_python.sh
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/basic/tasks/rados_stress_watch.yaml
+++ b/suites/rados/basic/tasks/rados_stress_watch.yaml
@@ -5,3 +5,11 @@ tasks:
     clients:
       client.0:
         - rados/stress_watch.sh
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -13,3 +13,11 @@ tasks:
     - clocks not synchronized
 - mon_clock_skew_check:
     expect-skew: true
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/objectstore/filestore-idempotent-aio-journal.yaml
+++ b/suites/rados/objectstore/filestore-idempotent-aio-journal.yaml
@@ -7,3 +7,11 @@ tasks:
       global:
         journal aio: true
 - filestore_idempotent:
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/objectstore/filestore-idempotent.yaml
+++ b/suites/rados/objectstore/filestore-idempotent.yaml
@@ -4,3 +4,11 @@ tasks:
 - install:
 - ceph:
 - filestore_idempotent:
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/objectstore/objectstore.yaml
+++ b/suites/rados/objectstore/objectstore.yaml
@@ -6,3 +6,11 @@ tasks:
     client.0:
       - mkdir $TESTDIR/ostest && cd $TESTDIR/ostest && ceph_test_objectstore
       - rm -rf $TESTDIR/ostest
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/singleton-nomsgr/all/msgr.yaml
+++ b/suites/rados/singleton-nomsgr/all/msgr.yaml
@@ -6,3 +6,11 @@ tasks:
     client.0:
           - ceph_test_async_driver
           - ceph_test_msgr
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/singleton/all/thrash-rados.yaml
+++ b/suites/rados/singleton/all/thrash-rados.yaml
@@ -20,3 +20,11 @@ tasks:
     clients:
       all:
       - rados/load-gen-mix-small.sh
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash-erasure-code/workloads/ec-radosbench.yaml
+++ b/suites/rados/thrash-erasure-code/workloads/ec-radosbench.yaml
@@ -4,3 +4,11 @@ tasks:
     time: 1800
     unique_pool: true
     ec_pool: true
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/admin_socket_objecter_requests.yaml
+++ b/suites/rados/thrash/workloads/admin_socket_objecter_requests.yaml
@@ -11,3 +11,11 @@ tasks:
     client.0:
       objecter_requests:
         test: "http://ceph.newdream.net/git/?p=ceph.git;a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/cache-agent-big.yaml
+++ b/suites/rados/thrash/workloads/cache-agent-big.yaml
@@ -28,3 +28,11 @@ tasks:
       write: 100
       delete: 50
       copy_from: 50
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/cache-agent-small.yaml
+++ b/suites/rados/thrash/workloads/cache-agent-small.yaml
@@ -25,3 +25,11 @@ tasks:
       write: 100
       delete: 50
       copy_from: 50
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/cache-pool-snaps.yaml
+++ b/suites/rados/thrash/workloads/cache-pool-snaps.yaml
@@ -31,3 +31,11 @@ tasks:
       snap_create: 50
       snap_remove: 50
       rollback: 50
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/cache-snaps.yaml
+++ b/suites/rados/thrash/workloads/cache-snaps.yaml
@@ -30,3 +30,11 @@ tasks:
       snap_create: 50
       snap_remove: 50
       rollback: 50
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/cache.yaml
+++ b/suites/rados/thrash/workloads/cache.yaml
@@ -26,3 +26,11 @@ tasks:
       flush: 50
       try_flush: 50
       evict: 50
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/pool-snaps-few-objects.yaml
+++ b/suites/rados/thrash/workloads/pool-snaps-few-objects.yaml
@@ -12,3 +12,11 @@ tasks:
       snap_remove: 50
       rollback: 50
       copy_from: 50
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/rados_api_tests.yaml
+++ b/suites/rados/thrash/workloads/rados_api_tests.yaml
@@ -11,3 +11,11 @@ tasks:
     clients:
       client.0:
         - rados/test.sh
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/radosbench.yaml
+++ b/suites/rados/thrash/workloads/radosbench.yaml
@@ -9,3 +9,11 @@ tasks:
 - radosbench:
     clients: [client.0]
     time: 1800
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/readwrite.yaml
+++ b/suites/rados/thrash/workloads/readwrite.yaml
@@ -10,3 +10,11 @@ tasks:
       read: 45
       write: 45
       delete: 10
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/small-objects.yaml
+++ b/suites/rados/thrash/workloads/small-objects.yaml
@@ -19,3 +19,11 @@ tasks:
       copy_from: 50
       setattr: 25
       rmattr: 25
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/snaps-few-objects.yaml
+++ b/suites/rados/thrash/workloads/snaps-few-objects.yaml
@@ -11,3 +11,11 @@ tasks:
       snap_remove: 50
       rollback: 50
       copy_from: 50
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/thrash/workloads/write_fadvise_dontneed.yaml
+++ b/suites/rados/thrash/workloads/write_fadvise_dontneed.yaml
@@ -6,3 +6,11 @@ tasks:
     write_fadvise_dontneed: true
     op_weights:
       write: 100
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB

--- a/suites/rados/verify/validater/lockdep.yaml
+++ b/suites/rados/verify/validater/lockdep.yaml
@@ -3,3 +3,11 @@ overrides:
     conf:
       global:
         lockdep: true
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB


### PR DESCRIPTION
Add a hint to tasks that need more than 4GB RAM, 20GB disk per machine to
complete, as observed by running a job that turns out to fail with these
limits although it succeeds with 8GB RAM, 40GB disk per machine using
the OpenStack teuthology backend.

On a --subset X/18 rados run for hammer more than half of the ~200 tests
pass with 4GB RAM, 20GB disk which makes it a good default size.

Although these hints are likely to be more or less similar for all cloud
provisioning APIs, keep them OpenStack specific instead of attempting a
generalization out of nothing.

http://tracker.ceph.com/issues/12386 Refs: #12386

Signed-off-by: Loic Dachary <loic@dachary.org>