### PR TITLE
Fixes #12021 for upgrade/dumpling-firefly-x suite

### DIFF
--- a/suites/upgrade/dumpling-firefly-x/parallel/0-cluster/start.yaml
+++ b/suites/upgrade/dumpling-firefly-x/parallel/0-cluster/start.yaml
@@ -3,6 +3,7 @@ overrides:
     conf:
       mon:
         mon warn on legacy crush tunables: false
+        mon debug unsafe allow tier with nonempty snaps: true
     log-whitelist:
       - scrub mismatch
       - ScrubResult


### PR DESCRIPTION
added "mon debug unsafe allow tier with nonempty snaps: true"

@athanatos I missed this on this suite FYI

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>