### PR TITLE
tasks: fix syntax error in ceph.py

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -126,9 +126,9 @@ def ceph_log(ctx, config):
                         'root.root',
                         '/etc/logrotate.d/ceph-test.conf'
                     ]
+                )
                 remote.chcon('/etc/logrotate.d/ceph-test.conf',
                              'system_u:object_r:etc_t:s0')
-                )
 
     if ctx.config.get('log-rotate'):
         daemons = ctx.config.get('log-rotate')


### PR DESCRIPTION
From e195f9fa.

Signed-off-by: John Spray <john.spray@redhat.com>