### PR TITLE
Include `SyntaxError` checks in linter

### DIFF
--- a/tasks/multibench.py
+++ b/tasks/multibench.py
@@ -36,7 +36,7 @@ def task(ctx, config):
         "please list clients to run on"
 
     def run_one(num):
-    """Run test spawn from gevent"""
+        """Run test spawn from gevent"""
         start = time.time()
         benchcontext = copy.copy(config.get('radosbench'))
         iterations = 0
@@ -48,7 +48,7 @@ def task(ctx, config):
             iterations += 1
     log.info("Starting %s threads"%(str(config.get('segments', 3)),))
     segments = [
-        gevent.spawn(run_one, i) 
+        gevent.spawn(run_one, i)
         for i in range(0, int(config.get('segments', 3)))]
 
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ skipsdist = True
 [testenv:flake8]
 deps=
   flake8
-commands=flake8 --select=F --exclude=venv
+commands=flake8 --select=F,E9 --exclude=venv


### PR DESCRIPTION
It wasn't configured to error before, should prevent issues like this: https://github.com/ceph/ceph-qa-suite/pull/521
