### PR TITLE
calamari_setup: handle RHCS 1.2 (missing /mnt/MON)

### DIFF
--- a/tasks/calamari_setup.py
+++ b/tasks/calamari_setup.py
@@ -345,7 +345,7 @@ def deploy_ceph(ctx, cal_svr):
     # created local repos at all, but that is the subject of a future
     # change.)
 
-    r = cal_svr.run(args='/usr/bin/test -d /mnt/MON')
+    r = cal_svr.run(args='/usr/bin/test -d /mnt/MON', check_status=False)
     use_install_repo = (r.returncode == 0)
 
     # pre-1.3:


### PR DESCRIPTION
In RHCS 1.2 we don't have a `/mnt/MON` directory. The intention of 35c6363a1eaf5011e26be8561ffcd4e9324d13a2 was to handle this condition, but in 1.2, the non-zero return code makes Teuthology fail the whole test.

We don't want *Teuthology* itself to act on the return code here; we simply want to know what it was and structure the rest of the test accordingly.