### PR TITLE
calamari_setup: install "cli" utils on Calamari node

### DIFF
--- a/tasks/calamari_setup.py
+++ b/tasks/calamari_setup.py
@@ -377,6 +377,8 @@ def deploy_ceph(ctx, cal_svr):
                     ' '.join(all_osds))
         cmds.append('ceph-deploy install --no-adjust-repos --osd ' +
                     ' '.join(all_osds))
+        # We tell users to use `hostname` in our docs. Do the same here.
+        cmds.append('ceph-deploy install --no-adjust-repos --cli `hostname`')
     else:
         cmds.append('ceph-deploy install ' + ' '.join(all_machines))
 


### PR DESCRIPTION
In our RHCS 1.3 ceph-deploy docs, we tell users to run "ceph-deploy install --cli" on their calamari admin node, but our smoke test wasn't actually doing this.

See https://bugzilla.redhat.com/1252929 , "[Ubuntu 1.3.0] - ceph-deploy install --no-adjust-repos --cli `hostname` is failing with a Traceback error"