### PR TITLE
update the list of supported distributions

### DIFF
--- a/distros/supported/centos_6.5.yaml
+++ b/distros/supported/centos_6.5.yaml
@@ -1,1 +1,0 @@
-../all/centos_6.5.yaml

--- a/distros/supported/centos_7.0.yaml
+++ b/distros/supported/centos_7.0.yaml
@@ -1,0 +1,1 @@
+../all/centos_7.0.yaml

--- a/distros/supported/ubuntu_12.04.yaml
+++ b/distros/supported/ubuntu_12.04.yaml
@@ -1,1 +1,0 @@
-../all/ubuntu_12.04.yaml


### PR DESCRIPTION
CentOS 6 and Ubuntu 12.04 are not support after Infernalis.
CentOS 7 is supported starting with Infernalis.

Signed-off-by: Loic Dachary <loic@dachary.org>