### PR TITLE
Adds test for ceph/pull/5442

### DIFF
--- a/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
+++ b/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
@@ -1,0 +1,38 @@
+roles:
+- [mon.0, mds.a, osd.0, osd.1, osd.2, client.0, client.1]
+tasks:
+- install:
+- ceph:
+- exec:
+    client.0:
+    - ceph osd pool create data_cache 4
+    - ceph osd tier add data data_cache
+    - ceph osd tier cache-mode data_cache writeback
+    - ceph osd tier set-overlay data data_cache
+    - ceph osd pool set data_cache hit_set_type bloom
+    - ceph osd pool set data_cache hit_set_count 8
+    - ceph osd pool set data_cache hit_set_period 3600
+    - ceph osd pool set data_cache min_read_recency_for_promote 0
+- ceph-fuse:
+- exec:
+    client.0:
+      - sudo chmod 777 $TESTDIR/mnt.0/
+      - dd if=/dev/urandom of=$TESTDIR/mnt.0/foo bs=1M count=5
+      - ls -al $TESTDIR/mnt.0/foo
+      - truncate --size 0 $TESTDIR/mnt.0/foo
+      - ls -al $TESTDIR/mnt.0/foo
+      - dd if=/dev/urandom of=$TESTDIR/mnt.0/foo bs=1M count=5
+      - ls -al $TESTDIR/mnt.0/foo
+      - cp $TESTDIR/mnt.0/foo /tmp/foo
+      - sync
+      - rados -p data_cache ls -
+      - sleep 10
+      - rados -p data_cache ls -
+      - rados -p data_cache cache-flush-evict-all
+      - rados -p data_cache ls -
+      - sleep 1
+- exec:
+    client.1:
+      - hexdump -C /tmp/foo | head
+      - hexdump -C $TESTDIR/mnt.1/foo | head
+      - cmp $TESTDIR/mnt.1/foo /tmp/foo


### PR DESCRIPTION
This is meant to exercise the code for https://github.com/ceph/ceph/pull/5442

Checked against hammer to ensure it [fails] \(test passes on [wip-12551]\). The osd logs for failed/passed jobs show little differences between them (in terms of osd ops); truncate `seq` and `size` are similar on both outputs but given that the changes in the PR do get exercised, I believe the patch is what makes the difference (although I could be wrong).

The test passes on hammer if we wait for the client to finish the (actual) async `truncate` by including a `sleep` between the truncate and the flush/eviction (e.g. `sleep 10`). The actual error message is:

```
2015-08-26 00:34:17.553532 7fdd159eb700  1 -- 10.214.133.22:6804/23913 --> 10.214.133.22:0/1025141 -- osd_op_reply(3 10000000000.00000016 [cache-evict] v0'0 uv0 ondisk = -16 ((16) Device or resource busy)) v6 -- ?+0 0xa41fe40 con 0x731d9c0
```

Seems that the eviction is trying to read truncated objects before they are actually truncated, which I believe is the case we're trying to recreate.

cc: @liewegas @athanatos

[wip-12551]: http://pulpito.ceph.com/ivo-2015-08-26_00:22:32-rados-wip-12551---basic-multi/
[fails]: http://pulpito.ceph.com/ivo-2015-08-26_00:22:38-rados-hammer---basic-multi/
