### PR TITLE
suites/rados/thrash: reduce rados bench run time

### DIFF
--- a/suites/rados/thrash-erasure-code/workloads/ec-radosbench.yaml
+++ b/suites/rados/thrash-erasure-code/workloads/ec-radosbench.yaml
@@ -1,6 +1,6 @@
 tasks:
 - radosbench:
     clients: [client.0]
-    time: 1800
+    time: 300
     unique_pool: true
     ec_pool: true

--- a/suites/rados/thrash/workloads/radosbench.yaml
+++ b/suites/rados/thrash/workloads/radosbench.yaml
@@ -8,4 +8,4 @@ overrides:
 tasks:
 - radosbench:
     clients: [client.0]
-    time: 1800
+    time: 300


### PR DESCRIPTION
1800 sec was a bit too long and also generates too many data. Using
a short run would make the rados suite faster.
Note the upgrade suite still uses the long run(1800 sec) to produce
enough stress.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>