### PR TITLE
tasks/qemu: avoid adding duplicated entries to /etc/exports

### DIFF
--- a/tasks/qemu.py
+++ b/tasks/qemu.py
@@ -181,6 +181,9 @@ def _setup_nfs_mount(remote, client, mount_dir):
         dir=export_dir
     )
     remote.run(args=[
+        'sudo', 'sed', '-i', '/^\/export\//d', "/etc/exports",
+    ])
+    remote.run(args=[
         'echo', export, run.Raw("|"),
         'sudo', 'tee', '-a', "/etc/exports",
     ])


### PR DESCRIPTION
try deleting leftover entries for previous job

Fixes: #12806
Signed-off-by: Yan, Zheng <zyan@redhat.com>