### PR TITLE
tasks/scrub_test: sudo ls ...

### DIFF
--- a/tasks/scrub_test.py
+++ b/tasks/scrub_test.py
@@ -84,7 +84,7 @@ def task(ctx, config):
     # fuzz time
     ls_fp = StringIO()
     osd_remote.run(
-        args=[ 'ls', data_path ],
+        args=[ 'sudo', 'ls', data_path ],
         stdout=ls_fp,
     )
     ls_out = ls_fp.getvalue()


### PR DESCRIPTION
/var/lib/ceph/osd/* is owned by ceph now; ubuntu user can't read
it.

Fixes: #12878
Signed-off-by: Sage Weil <sage@redhat.com>