### PR TITLE
tasks/ceph_manager: dump pgs when recover times out

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -1608,8 +1608,12 @@ class CephManager:
                     start = time.time()
                 else:
                     self.log("no progress seen, keeping timeout for now")
-                    assert time.time() - start < timeout, \
-                        'failed to recover before timeout expired'
+                    if time.time() - start >= timeout:
+                        self.log('dumping pgs')
+                        out = self.raw_cluster_cmd('pg', 'dump')
+                        self.log(out)
+                        assert time.time() - start < timeout, \
+                            'failed to recover before timeout expired'
             cur_active_recovered = self.get_num_active_recovered()
             if cur_active_recovered != num_active_recovered:
                 start = time.time()


### PR DESCRIPTION
It is really hard to map a stuck recovery back to the pgs that
are stuck.  This will make it easy.

Signed-off-by: Sage Weil sage@redhat.com
