### PR TITLE
suites/hammer/older: do not upgrade client while running RBD import/export

### DIFF
--- a/suites/upgrade/hammer/older/0-cluster/start.yaml
+++ b/suites/upgrade/hammer/older/0-cluster/start.yaml
@@ -17,4 +17,4 @@ roles:
   - osd.4
   - osd.5
   - client.0
-  - client.1
+- - client.1

--- a/suites/upgrade/hammer/older/2-workload/rbd.yaml
+++ b/suites/upgrade/hammer/older/2-workload/rbd.yaml
@@ -2,7 +2,7 @@ workload:
    sequential:
    - workunit:
        clients:
-         client.0:
+         client.1:
            - rbd/import_export.sh
        env:
          RBD_CREATE_ARGS: --new-format

--- a/suites/upgrade/hammer/older/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
+++ b/suites/upgrade/hammer/older/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
@@ -1,7 +1,8 @@
 upgrade-sequence:
    sequential:
    - install.upgrade:
-      all:
+       mon.a:
+       mon.b:
    - print: "**** done install.upgrade hammer"
    - ceph.restart: [mon.a]
    - sleep:

--- a/suites/upgrade/hammer/older/3-upgrade-sequence/upgrade-osd-mon-mds.yaml
+++ b/suites/upgrade/hammer/older/3-upgrade-sequence/upgrade-osd-mon-mds.yaml
@@ -1,7 +1,8 @@
 upgrade-sequence:
    sequential:
    - install.upgrade:
-      all:
+       mon.a:
+       mon.b:
    - print: "**** done install.upgrade hammer"
    - ceph.restart: [osd.0]
    - sleep:


### PR DESCRIPTION
Between the Giant and Hammer releases, the symbols exported from librados/librbd
were cleaned up.  This creates a short window of time between installing
upgraded packages where symbol lookup errors could occur.

Fixes: #12563
Signed-off-by: Jason Dillaman <dillaman@redhat.com>