### PR TITLE
rados: 'failed to encode ...' warnings are normal on upgrades

### DIFF
--- a/suites/rados/singleton-nomsgr/all/11429.yaml
+++ b/suites/rados/singleton-nomsgr/all/11429.yaml
@@ -19,6 +19,7 @@ overrides:
     - slow request
     - scrub mismatch
     - ScrubResult
+    - failed to encode
 roles:
 - - mon.a
   - mds.a

--- a/suites/rados/upgrade/hammer-x-singleton/3-thrash/default.yaml
+++ b/suites/rados/upgrade/hammer-x-singleton/3-thrash/default.yaml
@@ -4,6 +4,7 @@ overrides:
     - wrongly marked me down
     - objects unfound and apparently lost
     - log bound mismatch
+    - failed to encode
 tasks:
 - thrashosds:
     timeout: 1200


### PR DESCRIPTION
Fixes: #12973
Signed-off-by: Sage Weil <sage@redhat.com>