### PR TITLE
Use old branches as is without 'ceph-' for firefly, hammer etc

### DIFF
--- a/tasks/s3tests.py
+++ b/tasks/s3tests.py
@@ -124,12 +124,16 @@ def download(ctx, config):
     assert isinstance(config, dict)
     log.info('Downloading s3-tests...')
     testdir = teuthology.get_testdir(ctx)
+    s3_branches = [ 'giant', 'firefly', 'firefly-original', 'hammer' ]
     for (client, cconf) in config.items():
         branch = cconf.get('force-branch', None)
         if not branch:
             ceph_branch = ctx.config.get('branch')
             suite_branch = ctx.config.get('suite_branch', ceph_branch)
-            branch = cconf.get('branch', 'ceph-' + suite_branch)
+            if suite_branch in s3_branches:
+                branch = cconf.get('branch', suite_branch)
+	    else:
+                branch = cconf.get('branch', 'ceph-' + suite_branch)
         if not branch:
             raise ValueError(
                 "Could not determine what branch to use for s3tests!")


### PR DESCRIPTION
Use old branches as is without 'ceph-' for firefly, hammer etc

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>