### PR TITLE
ceph: wait for CephFS to be healthy before proceeding

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -292,6 +292,9 @@ def cephfs_setup(ctx, config):
             'ceph',
             'mds', 'set_max_mds', str(num_active)])
 
+        # make sure the FS is accessible before proceeding
+        ceph_fs.wait_for_daemons(timeout=300)
+
     yield
 
 


### PR DESCRIPTION
Ceph PR https://github.com/ceph/ceph/pull/5416 was causing tests to occasionally fail because it took some time for the MDSes to actually be ready to go. Wait for them to be happy during initial setup.

We set a 300 second timeout just to make sure we don't eat up machines for forever.