### PR TITLE
do not duplicate CentOS 7 runs

### DIFF
--- a/distros/a-supported-distro.yaml
+++ b/distros/a-supported-distro.yaml
@@ -1,0 +1,1 @@
+all/centos_7.0.yaml

--- a/distros/supported/a-supported-distro.yaml
+++ b/distros/supported/a-supported-distro.yaml
@@ -1,1 +1,0 @@
-../all/centos_7.0.yaml

--- a/suites/upgrade/hammer-x/v0-94-4-stop/a-supported-distro.yaml
+++ b/suites/upgrade/hammer-x/v0-94-4-stop/a-supported-distro.yaml
@@ -1,1 +1,1 @@
-../../../../distros/supported/a-supported-distro.yaml
+../../../../distros/a-supported-distro.yaml


### PR DESCRIPTION
The a-supported-distro.yaml file must be outside of the supported distro
directory otherwise it will have all suites including the distro
directory run CentOS 7 jobs twice.

Signed-off-by: Loic Dachary <loic@dachary.org>