### PR TITLE
buildpackages: get Ceph git url via get_ceph_git_url()

### DIFF
--- a/tasks/buildpackages.py
+++ b/tasks/buildpackages.py
@@ -101,7 +101,7 @@ def task(ctx, config):
             'cpus': 1,
         }, select)
         cmd = (". " + os.environ['HOME'] + "/.ssh_agent ; flock /tmp/buildpackages make -C " + d +
-               " CEPH_GIT_BASE_URL=" + teuth_config.ceph_git_base_url + 
+               " CEPH_GIT_URL=" + teuth_config.get_ceph_git_url() +
                " CEPH_PKG_TYPE=" + gitbuilder.pkg_type +
                " CEPH_OS_TYPE=" + ctx.config['os_type'] +
                " CEPH_OS_VERSION=" + ctx.config['os_version'] +

--- a/tasks/buildpackages/Makefile
+++ b/tasks/buildpackages/Makefile
@@ -28,7 +28,7 @@ ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-basic-${CEPH_SHA1}: packages-rep
 	ip=$(call get_ip,$@) ; \
 	scp make-${CEPH_PKG_TYPE}.sh common.sh ubuntu@$$ip: ; \
 	packages_repository=$(call get_ip,${<F}) ; \
-	ssh -tt -A ubuntu@$$ip bash ./make-${CEPH_PKG_TYPE}.sh $$packages_repository ${CEPH_DIST} ${CEPH_GIT_BASE_URL} ${CEPH_SHA1}
+	ssh -tt -A ubuntu@$$ip bash ./make-${CEPH_PKG_TYPE}.sh $$packages_repository ${CEPH_DIST} ${CEPH_GIT_URL} ${CEPH_SHA1}
 	mkdir -p ${D}/${@D} ; touch ${D}/$@
 
 clobber:

--- a/tasks/buildpackages/common.sh
+++ b/tasks/buildpackages/common.sh
@@ -20,10 +20,10 @@ function install_deps() {
 }
 
 function get_ceph() {
-    local git_base_url=$1
+    local git_ceph_url=$1
     local sha1=$2
 
-    test -d ceph || git clone ${git_base_url}/ceph
+    test -d ceph || git clone ${git_ceph_url}
     cd ceph
     git checkout ${sha1}
 }

--- a/tasks/buildpackages/make-deb.sh
+++ b/tasks/buildpackages/make-deb.sh
@@ -24,7 +24,7 @@ set -xe
 base=/tmp/release
 gitbuilder_host=$1
 codename=$2
-git_base_url=$3
+git_ceph_url=$3
 sha1=$4
 
 sudo apt-get update
@@ -32,7 +32,7 @@ sudo apt-get install -y git
 
 source $(dirname $0)/common.sh
 
-get_ceph $git_base_url $sha1
+get_ceph $git_ceph_url $sha1
 install_deps
 
 #codename=$(lsb_release -sc)

--- a/tasks/buildpackages/make-rpm.sh
+++ b/tasks/buildpackages/make-rpm.sh
@@ -25,14 +25,14 @@ set -xe
 base=/tmp/release
 gitbuilder_host=$1
 codename=$2
-git_base_url=$3
+git_ceph_url=$3
 sha1=$4
 
 sudo yum install -y git
 
 source $(dirname $0)/common.sh
 
-get_ceph $git_base_url $sha1
+get_ceph $git_ceph_url $sha1
 install_deps
 
 #id=$(lsb_release -s -i | tr A-Z a-z)


### PR DESCRIPTION
Instead of relying on git_base_url, use the get_ceph_git_url() to obtain
the URL of the Ceph repository to use with git clone. This allows the
user to override it via the git_ceph_url configuration option and the
--git-ceph-url command line option to teuthology-openstack.

http://tracker.ceph.com/issues/11883 Refs: #11883

Signed-off-by: Loic Dachary <loic@dachary.org>