### PR TITLE
buildpackages: user-data must be per os-type/os-version

### DIFF
--- a/tasks/buildpackages/Makefile
+++ b/tasks/buildpackages/Makefile
@@ -22,10 +22,11 @@ packages-repository:
 	mkdir -p ${D}/${@D} ; touch ${D}/$@
 
 ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-basic-${CEPH_SHA1}: packages-repository
-	openstack server create --image 'teuthology-${CEPH_OS_TYPE}-${CEPH_OS_VERSION}' --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data user-data.txt --wait $@ ; sleep 30
+	openstack server create --image 'teuthology-${CEPH_OS_TYPE}-${CEPH_OS_VERSION}' --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@ ; sleep 30
 	set -ex ; \
 	trap "openstack server delete $@" EXIT ; \
 	ip=$(call get_ip,$@) ; \
+	for delay in 1 2 4 8 8 8 8 8 8 8 8 8 16 16 16 16 16 32 32 32 64 128 256 512 ; do if ssh -o 'ConnectTimeout=3' $$ip bash -c '"grep -q READYTORUN /var/log/cloud-init*.log"' ; then break ; else sleep $$delay ; fi ; done ; \
 	scp make-${CEPH_PKG_TYPE}.sh common.sh ubuntu@$$ip: ; \
 	packages_repository=$(call get_ip,${<F}) ; \
 	ssh -tt -A ubuntu@$$ip bash ./make-${CEPH_PKG_TYPE}.sh $$packages_repository ${CEPH_DIST} ${CEPH_GIT_URL} ${CEPH_SHA1}

--- a/tasks/buildpackages/centos-6.5-user-data.txt
+++ b/tasks/buildpackages/centos-6.5-user-data.txt
@@ -1,0 +1,15 @@
+#cloud-config
+bootcmd:
+ - yum install -y yum-utils && yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/6/x86_64/ && yum install --nogpgcheck -y epel-release && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6 && rm /etc/yum.repos.d/dl.fedoraproject.org*
+ - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config
+ - ( echo 'Defaults !requiretty' ; echo 'Defaults visiblepw' ) | tee /etc/sudoers.d/cephlab_sudo
+preserve_hostname: true
+system_info:
+  default_user:
+    name: ubuntu
+packages:
+ - dracut-modules-growroot
+runcmd:
+ - mkinitrd --force /boot/initramfs-2.6.32-573.3.1.el6.x86_64.img 2.6.32-573.3.1.el6.x86_64
+ - reboot
+final_message: "READYTORUN"

--- a/tasks/buildpackages/centos-7.0-user-data.txt
+++ b/tasks/buildpackages/centos-7.0-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt

--- a/tasks/buildpackages/ubuntu-14.04-user-data.txt
+++ b/tasks/buildpackages/ubuntu-14.04-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt

--- a/tasks/buildpackages/user-data.txt
+++ b/tasks/buildpackages/user-data.txt
@@ -2,3 +2,4 @@
 system_info:
   default_user:
     name: ubuntu
+final_message: "READYTORUN"


### PR DESCRIPTION
CentOS 6.5 needs to install a package and reboot to grow the root file
system. Instead of assuming a common user-data.txt file can fit all
Operating Systems, make one user data per os-type/os-version combination.

Signed-off-by: Loic Dachary <loic@dachary.org>