### PR TITLE
buildpackages: implicit for OpenStack

### DIFF
--- a/debug/buildpackages.yaml
+++ b/debug/buildpackages.yaml
@@ -1,0 +1,6 @@
+tasks:
+    - buildpackages:
+        machine:
+          disk: 40 # GB
+          ram: 15000 # MB
+          cpus: 16

--- a/suites/teuthology/buildpackages/tasks/builpackages.yaml
+++ b/suites/teuthology/buildpackages/tasks/builpackages.yaml
@@ -1,9 +1,4 @@
 roles:
     - [mon.0, client.0]
 tasks:
-    - buildpackages:
-        machine:
-          disk: 40 # GB
-          ram: 15000 # MB
-          cpus: 16
     - install:


### PR DESCRIPTION
When using the teuthology-openstack command, buildpackages is implicit
and does not need to be included when running the test suite. Move the
stanza to the debug directory as a reminder when debuging.

Signed-off-by: Loic Dachary <loic@dachary.org>