### PR TITLE
ceph-deploy: always zap disk before creating an osd

### DIFF
--- a/tasks/ceph_deploy.py
+++ b/tasks/ceph_deploy.py
@@ -142,12 +142,12 @@ def get_dev_for_osd(ctx, config):
                 jd_index = dindex + 1
                 dev_short = devs[dindex].split('/')[-1]
                 jdev_short = devs[jd_index].split('/')[-1]
-                osd_devs.append('{host}:{dev}:{jdev}'.format(host=shortname, dev=dev_short, jdev=jdev_short))
+                osd_devs.append((shortname, dev_short, jdev_short))
         else:
             assert num_osds <= len(devs), 'fewer disks than osds ' + shortname
             for dev in devs[:num_osds]:
                 dev_short = dev.split('/')[-1]
-                osd_devs.append('{host}:{dev}:{jdev}'.format(host=shortname, dev=dev_short, jdev=dev_short))
+                osd_devs.append((shortname, dev_short))
     return osd_devs
 
 def get_all_nodes(ctx, config):
@@ -259,28 +259,23 @@ def build_ceph_cluster(ctx, config):
                     raise RuntimeError("ceph-deploy: Failed to delete monitor")
 
         node_dev_list = get_dev_for_osd(ctx, config)
-        osd_create_cmd = './ceph-deploy osd create --zap-disk '
         for d in node_dev_list:
+            node = d[0]
+            for disk in d[1:]:
+                zap = './ceph-deploy disk zap ' + node + ':' + disk
+                estatus = execute_ceph_deploy(zap)
+                if estatus != 0:
+                    raise RuntimeError("ceph-deploy: Failed to zap osds")
+            osd_create_cmd = './ceph-deploy osd create '
             if config.get('dmcrypt') is not None:
-                osd_create_cmd_d = osd_create_cmd+'--dmcrypt'+" "+d
-            else:
-                osd_create_cmd_d = osd_create_cmd+d
-            estatus_osd = execute_ceph_deploy(osd_create_cmd_d)
+                osd_create_cmd += '--dmcrypt '
+            osd_create_cmd += ":".join(d)
+            estatus_osd = execute_ceph_deploy(osd_create_cmd)
             if estatus_osd == 0:
                 log.info('successfully created osd')
                 no_of_osds += 1
             else:
-                disks = d.split(':')
-                dev_disk = disks[0]+":"+disks[1]
-                j_disk = disks[0]+":"+disks[2]
-                zap_disk = './ceph-deploy disk zap '+dev_disk+" "+j_disk
-                execute_ceph_deploy(zap_disk)
-                estatus_osd = execute_ceph_deploy(osd_create_cmd_d)
-                if estatus_osd == 0:
-                    log.info('successfully created osd')
-                    no_of_osds += 1
-                else:
-                    raise RuntimeError("ceph-deploy: Failed to create osds")
+                raise RuntimeError("ceph-deploy: Failed to create osds")
 
         if config.get('wait-for-healthy', True) and no_of_osds >= 2:
             is_healthy(ctx=ctx, config=None)


### PR DESCRIPTION
The existing logic is to ceph-deploy osd create --zap-disk which will
zap the data device before preparing it. However it will not zap the
journal device (see http://tracker.ceph.com/issues/13291).

If ceph-deploy osd create fails, a fall back will zap both the data
device and the journal and try prepare again. This could work if
the device preparation and activation was synchronous and catch all
errors that could be caused by an unclean journal device. However,
the activation is asynchronous and it is entirely possible for a device
to be prepared successfully and fail to activate in the background.

The data and journal device are always zapped before calling ceph-deploy
osd create. The logic is simpler and the overhead is low.

http://tracker.ceph.com/issues/13000 Fixes: #13000

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit 01d48a270ad526492dccbb0e363162f0befb0f9e)