### PR TITLE
ceph-deploy: fix ceph-deploy-branch config options

### DIFF
--- a/tasks/ceph_deploy.py
+++ b/tasks/ceph_deploy.py
@@ -29,10 +29,7 @@ def download_ceph_deploy(ctx, config):
     log.info('Downloading ceph-deploy...')
     testdir = teuthology.get_testdir(ctx)
     ceph_admin = ctx.cluster.only(teuthology.get_first_mon(ctx, config))
-    default_cd_branch = {'ceph-deploy-branch': 'master'}
-    ceph_deploy_branch = config.get(
-        'ceph-deploy',
-        default_cd_branch).get('ceph-deploy-branch')
+    ceph_deploy_branch = config.get('ceph-deploy-branch', 'master')
 
     ceph_admin.run(
         args=[
@@ -488,6 +485,8 @@ def task(ctx, config):
 
     if config.get('branch') is not None:
         assert isinstance(config['branch'], dict), 'branch must be a dictionary'
+
+    log.info('task ceph-deploy with config ' + str(config))
 
     with contextutil.nested(
          lambda: install_fn.ship_utilities(ctx=ctx, config=None),


### PR DESCRIPTION
The config paramter of download_ceph_deploy does not have a ceph-deploy
item, therefore the ceph-deploy-branch parameter is always assumed to be
master.

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit fdcfb79b3c57765441a6d15bea8ef2fcbcebf5f8)