### PR TITLE
log-whitelist 'reached quota' for librados test.sh

### DIFF
--- a/suites/powercycle/osd/tasks/rados_api_tests.yaml
+++ b/suites/powercycle/osd/tasks/rados_api_tests.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - reached quota
 tasks:
 - ceph-fuse:
 - workunit:

--- a/suites/rados/monthrash/workloads/rados_api_tests.yaml
+++ b/suites/rados/monthrash/workloads/rados_api_tests.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - reached quota
 tasks:
 - workunit:
     clients:

--- a/suites/rados/thrash/workloads/rados_api_tests.yaml
+++ b/suites/rados/thrash/workloads/rados_api_tests.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+      - reached quota
     crush_tunables: hammer
     conf:
       client:

--- a/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+      - reached quota
     conf:
       client:
         debug ms: 1

--- a/suites/smoke/basic/tasks/mon_thrash.yaml
+++ b/suites/smoke/basic/tasks/mon_thrash.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-whitelist:
+      - reached quota
     conf:
       global:
         ms inject delay max: 1

--- a/suites/smoke/basic/tasks/rados_api_tests.yaml
+++ b/suites/smoke/basic/tasks/rados_api_tests.yaml
@@ -3,6 +3,7 @@ tasks:
 - ceph:
     fs: ext4
     log-whitelist:
+    - reached quota
     - wrongly marked me down
     - objects unfound and apparently lost
 - thrashosds:

--- a/suites/upgrade/firefly-hammer-x/parallel/5-workload/rados_api.yaml
+++ b/suites/upgrade/firefly-hammer-x/parallel/5-workload/rados_api.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - reached quota
 workload2:
   sequential:
   - workunit:

--- a/suites/upgrade/hammer-x/parallel/5-final-workload/rados_mon_thrash.yaml
+++ b/suites/upgrade/hammer-x/parallel/5-final-workload/rados_mon_thrash.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - reached quota
 tasks:
   - mon_thrash:
       revive_delay: 20

--- a/suites/upgrade/hammer-x/point-to-point-x/point-to-point.yaml
+++ b/suites/upgrade/hammer-x/point-to-point-x/point-to-point.yaml
@@ -1,6 +1,7 @@
 overrides:
   ceph:
     log-whitelist:
+    - reached quota
     - scrub
     - osd_map_max_advance
     fs: xfs

--- a/suites/upgrade/hammer/point-to-point/point-to-point.yaml
+++ b/suites/upgrade/hammer/point-to-point/point-to-point.yaml
@@ -1,6 +1,7 @@
 overrides:
   ceph:
     log-whitelist:
+    - reached quota
     - scrub
     - osd_map_max_advance
     fs: xfs


### PR DESCRIPTION
A new test verifies that we are stopped by the pool quota (and get
the right error messages or block).  See ceph.git
32962740ce9211626d310a002b23afeb0d05b500.

Signed-off-by: Sage Weil <sage@redhat.com>