### PR TITLE
tasks/radosbench: wait just a bit longer

### DIFF
--- a/tasks/radosbench.py
+++ b/tasks/radosbench.py
@@ -92,7 +92,7 @@ def task(ctx, config):
     try:
         yield
     finally:
-        timeout = config.get('time', 360) * 5
+        timeout = config.get('time', 360) * 5 + 180
         log.info('joining radosbench (timing out after %ss)', timeout)
         run.wait(radosbench.itervalues(), timeout=timeout)
 


### PR DESCRIPTION
A run failed due to thrashing.. missed by about 30s (the osd
eventually sent the last reply but we'd already timed out).

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 3e30d5dfdf823b345a6ded71e32e016e4e7d1396)