### PR TITLE
tasks/ceph_fuse.py: virtual machines need flexible mount timeout

### DIFF
--- a/machine_types/vps.yaml
+++ b/machine_types/vps.yaml
@@ -10,3 +10,7 @@ overrides:
     default_idle_timeout: 1200
   s3tests:
     idle_timeout: 1200
+  ceph-fuse:
+    client.0:
+       mount_wait: 60
+       mount_timeout: 120

--- a/tasks/ceph_fuse.py
+++ b/tasks/ceph_fuse.py
@@ -79,6 +79,16 @@ def task(ctx, config):
                     mounted: false
             - ... do something that requires the FS unmounted ...
 
+    Example that adds more generous wait time for mount (for virtual machines):
+
+        tasks:
+        - ceph:
+        - ceph-fuse:
+            client.0:
+              mount_wait: 60 # default is 0, do not wait before checking /sys/
+              mount_timeout: 120 # default is 30, give up if /sys/ is not populated
+        - interactive:
+
     :param ctx: Context
     :param config: Configuration
     """

--- a/tasks/cephfs/fuse_mount.py
+++ b/tasks/cephfs/fuse_mount.py
@@ -100,11 +100,16 @@ class FuseMount(CephFSMount):
         self.fuse_daemon = proc
 
         # Wait for the connection reference to appear in /sys
+        mount_wait = self.client_config.get('mount_wait', 0)
+        if mount_wait > 0:
+            log.info("Fuse mount waits {0} seconds before checking /sys/".format(mount_wait))
+            time.sleep(mount_wait)            
+        timeout = self.client_config.get('mount_timeout', '30')
         waited = 0
         while list_connections() == pre_mount_conns:
             time.sleep(1)
             waited += 1
-            if waited > 30:
+            if waited > timeout:
                 raise RuntimeError("Fuse mount failed to populate /sys/ after {0} seconds".format(
                     waited
                 ))

--- a/tasks/cephfs/fuse_mount.py
+++ b/tasks/cephfs/fuse_mount.py
@@ -104,7 +104,7 @@ class FuseMount(CephFSMount):
         if mount_wait > 0:
             log.info("Fuse mount waits {0} seconds before checking /sys/".format(mount_wait))
             time.sleep(mount_wait)            
-        timeout = self.client_config.get('mount_timeout', '30')
+        timeout = int(self.client_config.get('mount_timeout', 30))
         waited = 0
         while list_connections() == pre_mount_conns:
             time.sleep(1)


### PR DESCRIPTION
1) add a wait time before the mount attempt to let the cluster get set up.
By default this should be skipped, but for VMs and known-slow systems we
can give them 60 seconds.
2) Make the timeout configurable, with a 30-second default, but override it
for VM tests.

http://tracker.ceph.com/issues/12320 Fixes: #12320

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit ec12f21a7ead9d82b575c4f927d5e7b73f85c3d5)