### PR TITLE
buildpackages: honour install priorities tags, branch, sha1

### DIFF
--- a/suites/teuthology/buildpackages/tasks/branch.yaml
+++ b/suites/teuthology/buildpackages/tasks/branch.yaml
@@ -1,0 +1,10 @@
+roles:
+    - [mon.0, client.0]
+tasks:
+    - install:
+        # branch has precedence over sha1
+        branch: hammer
+        sha1: e5b6eea91cc37434f78a987d2dd1d3edd4a23f3f # dumpling
+    - exec:
+        client.0:
+          - ceph --version | grep 'version 0.94'

--- a/suites/teuthology/buildpackages/tasks/builpackages.yaml
+++ b/suites/teuthology/buildpackages/tasks/builpackages.yaml
@@ -1,4 +1,0 @@
-roles:
-    - [mon.0, client.0]
-tasks:
-    - install:

--- a/suites/teuthology/buildpackages/tasks/default.yaml
+++ b/suites/teuthology/buildpackages/tasks/default.yaml
@@ -1,0 +1,14 @@
+roles:
+    - [client.0]
+tasks:
+    - install:
+        tag: v0.94.1
+    - exec:
+        client.0:
+          - ceph --version | grep 'version 0.94.1'
+    - install.upgrade:
+        client.0:
+          tag: v0.94.3
+    - exec:
+        client.0:
+          - ceph --version | grep 'version 0.94.3'

--- a/suites/teuthology/buildpackages/tasks/tag.yaml
+++ b/suites/teuthology/buildpackages/tasks/tag.yaml
@@ -1,0 +1,11 @@
+roles:
+    - [mon.0, client.0]
+tasks:
+    - install:
+        # tag has precedence over branch and sha1
+        tag: v0.94.1
+        branch: firefly
+        sha1: e5b6eea91cc37434f78a987d2dd1d3edd4a23f3f # dumpling
+    - exec:
+        client.0:
+          - ceph --version | grep 'version 0.94.1'

--- a/tasks/buildpackages.py
+++ b/tasks/buildpackages.py
@@ -103,11 +103,11 @@ def task(ctx, config):
         cmd = (". " + os.environ['HOME'] + "/.ssh_agent ; flock --close /tmp/buildpackages make -C " + d +
                " CEPH_GIT_URL=" + teuth_config.get_ceph_git_url() +
                " CEPH_PKG_TYPE=" + gitbuilder.pkg_type +
-               " CEPH_OS_TYPE=" + ctx.config['os_type'] +
-               " CEPH_OS_VERSION=" + ctx.config['os_version'] +
+               " CEPH_OS_TYPE=" + gitbuilder.os_type +
+               " CEPH_OS_VERSION=" + gitbuilder.os_version +
                " CEPH_DIST=" + gitbuilder.distro +
                " CEPH_ARCH=" + gitbuilder.arch +
-               " CEPH_SHA1=" + (sha1 or '')  +
+               " CEPH_SHA1=" + sha1 +
                " CEPH_TAG=" + (tag or '') +
                " CEPH_BRANCH=" + (branch or '') +
                " CEPH_REF=" + ref +

--- a/tasks/buildpackages.py
+++ b/tasks/buildpackages.py
@@ -22,6 +22,66 @@ def get_install_config(ctx):
     for task in ctx.config['tasks']:
         if task.keys()[0] == 'install':
             config = task['install']
+def get_tag_branch_sha1(gitbuilder):
+    """The install config may have contradicting tag/branch and sha1.
+    When suite.py prepares the jobs, it always overrides the sha1 with
+    whatever default is provided on the command line with --distro
+    and what is found in the gitbuilder. If it turns out that the
+    tag or the branch in the install config task is about another sha1,
+    it will override anyway. For instance:
+
+    install:
+       tag: v0.94.1
+
+    will be changed into
+
+    install:
+       tag: v0.94.1
+       sha1: 12345
+
+    even though v0.94.1 is not sha1 12345. This is does not cause
+    problem with the install task because
+    GitbuilderProject._get_uri_reference is used to figure out what to
+    install from the gitbuilder and this function gives priority to
+    the tag, if not found the branch, if not found the sha1.
+
+    It is however confusing and this function returns a sha1 that is
+    consistent with the tag or the branch being used.
+
+    """
+
+    uri_reference = gitbuilder.uri_reference
+    url = gitbuilder.base_url
+    assert '/' + uri_reference in url, \
+        (url + ' (from template ' + teuth_config.baseurl_template +
+         ') does not contain /' + uri_reference)
+    log.info('uri_reference ' + uri_reference)
+    if uri_reference.startswith('ref/'):
+        ref = re.sub('^ref/', '', uri_reference) # do not use basename because the ref may contain a /
+        ceph_git_url = teuth_config.get_ceph_git_url()
+        cmd = "git ls-remote " + ceph_git_url + " " + ref
+        output = check_output(cmd, shell=True)
+        if not output:
+            raise Exception(cmd + " returns nothing")
+        lines = output.splitlines()
+        if len(lines) != 1:
+            raise Exception(
+                cmd + " returns " + output +
+                " which contains " + str(len(lines)) +
+                " lines instead of exactly one")
+        log.info(cmd + " returns " + lines[0])
+        (sha1, ref) = lines[0].split()
+        if ref.startswith('refs/heads/'):
+            tag = None
+            branch = re.sub('^refs/heads/', '', ref)
+        elif ref.startswith('refs/tags/'):
+            tag = re.sub('^refs/tags/', '', ref)
+            branch = None
+    else:
+        sha1 = os.path.basename(uri_reference)
+        tag = None
+        branch = None
+    return (tag, branch, sha1)
     if config is None:
         config = {}
     assert isinstance(config, dict), \

--- a/tasks/buildpackages.py
+++ b/tasks/buildpackages.py
@@ -100,7 +100,9 @@ def task(ctx, config):
             'ram': 1024, # MB
             'cpus': 1,
         }, select)
-        cmd = (". " + os.environ['HOME'] + "/.ssh_agent ; flock --close /tmp/buildpackages make -C " + d +
+        cmd = (". " + os.environ['HOME'] + "/.ssh_agent ; " +
+               " flock --close /tmp/buildpackages-" + sha1 +
+               " make -C " + d +
                " CEPH_GIT_URL=" + teuth_config.get_ceph_git_url() +
                " CEPH_PKG_TYPE=" + gitbuilder.pkg_type +
                " CEPH_OS_TYPE=" + gitbuilder.os_type +

--- a/tasks/buildpackages/common.sh
+++ b/tasks/buildpackages/common.sh
@@ -26,4 +26,6 @@ function get_ceph() {
     test -d ceph || git clone ${git_ceph_url}
     cd ceph
     git checkout ${sha1}
+    # see http://tracker.ceph.com/issues/13426
+    perl -pi -e 's|git://ceph.com/git/ceph-object-corpus.git|https://github.com/ceph/ceph-object-corpus.git|' .gitmodules
 }

--- a/tasks/buildpackages/make-deb.sh
+++ b/tasks/buildpackages/make-deb.sh
@@ -51,7 +51,6 @@ vers=$(git describe --match "v*" | sed s/^v//)
 # change each time it is modified.
 #
 dvers="$vers-1"
-sha1=$(git rev-parse HEAD)
 : ${NPROC:=$(nproc)}
 ceph_dir=$(pwd)
 

--- a/tasks/buildpackages/make-deb.sh
+++ b/tasks/buildpackages/make-deb.sh
@@ -136,7 +136,7 @@ EOF
     echo $sha1 > $sha1_dir/sha1
     ref_dir=$codename/$base/ref
     mkdir -p $ref_dir
-    ( cd ${ceph_dir} ; git for-each-ref refs/tags/** refs/heads/** ) | grep $sha1 | while read sha1 type ref ; do
+    ( cd ${ceph_dir} ; git for-each-ref refs/tags/** refs/remotes/origin/** ) | grep $sha1 | while read sha1 type ref ; do
         base_ref=$(basename $ref)
         ( cd $ref_dir ; ln -sf ../sha1/$sha1 $base_ref )
     done

--- a/tasks/buildpackages/make-rpm.sh
+++ b/tasks/buildpackages/make-rpm.sh
@@ -47,7 +47,6 @@ releasedir=$base/$(lsb_release -si)/WORKDIR
 # d) contains the short hash of the commit
 #
 vers=$(git describe --long --match "v*" | sed s/^v//)
-sha1=$(git rev-parse HEAD)
 : ${NPROC:=$(nproc)}
 ceph_dir=$(pwd)
 

--- a/tasks/buildpackages/make-rpm.sh
+++ b/tasks/buildpackages/make-rpm.sh
@@ -233,7 +233,7 @@ function build_rpm_repo() {
 
     ref_dir=${buildarea}/../$codename/$base/ref
     mkdir -p $ref_dir
-    ( cd ${ceph_dir} ; git for-each-ref refs/tags/** refs/heads/** ) | grep $sha1 | while read sha1 type ref ; do
+    ( cd ${ceph_dir} ; git for-each-ref refs/tags/** refs/remotes/origin/** ) | grep $sha1 | while read sha1 type ref ; do
         base_ref=$(basename $ref)
         ( cd $ref_dir ; ln -sf ../sha1/$sha1 $base_ref )
     done

--- a/tasks/tests/test_buildpackages.py
+++ b/tasks/tests/test_buildpackages.py
@@ -1,0 +1,170 @@
+# py.test -v -s tests/test_buildpackages.py
+
+from mock import patch, Mock
+
+from .. import buildpackages
+from teuthology import packaging
+
+def test_get_tag_branch_sha1():
+    gitbuilder = packaging.GitbuilderProject(
+        'ceph',
+        {
+            'os_type': 'centos',
+            'os_version': '7.0',
+        })
+    (tag, branch, sha1) = buildpackages.get_tag_branch_sha1(gitbuilder)
+    assert tag == None
+    assert branch == None
+    assert sha1 is not None
+
+    gitbuilder = packaging.GitbuilderProject(
+        'ceph',
+        {
+            'os_type': 'centos',
+            'os_version': '7.0',
+            'sha1': 'asha1',
+        })
+    (tag, branch, sha1) = buildpackages.get_tag_branch_sha1(gitbuilder)
+    assert tag == None
+    assert branch == None
+    assert sha1 == 'asha1'
+
+    remote = Mock
+    remote.arch = 'x86_64'
+    remote.os = Mock
+    remote.os.name = 'ubuntu'
+    remote.os.version = '14.04'
+    remote.os.codename = 'trusty'
+    remote.system_type = 'deb'
+    ctx = Mock
+    ctx.cluster = Mock
+    ctx.cluster.remotes = {remote: ['client.0']}
+
+    expected_tag = 'v0.94.1'
+    expected_sha1 = 'expectedsha1'
+    def check_output(cmd, shell):
+        assert shell == True
+        return expected_sha1 + " refs/tags/" + expected_tag
+    with patch.multiple(
+            buildpackages,
+            check_output=check_output,
+    ):
+        gitbuilder = packaging.GitbuilderProject(
+            'ceph',
+            {
+                'os_type': 'centos',
+                'os_version': '7.0',
+                'sha1': 'asha1',
+                'all': {
+                    'tag': tag,
+                },
+            },
+            ctx = ctx,
+            remote = remote)
+        (tag, branch, sha1) = buildpackages.get_tag_branch_sha1(gitbuilder)
+        assert tag == expected_tag
+        assert branch == None
+        assert sha1 == expected_sha1
+
+    expected_branch = 'hammer'
+    expected_sha1 = 'otherexpectedsha1'
+    def check_output(cmd, shell):
+        assert shell == True
+        return expected_sha1 + " refs/heads/" + expected_branch
+    with patch.multiple(
+            buildpackages,
+            check_output=check_output,
+    ):
+        gitbuilder = packaging.GitbuilderProject(
+            'ceph',
+            {
+                'os_type': 'centos',
+                'os_version': '7.0',
+                'sha1': 'asha1',
+                'all': {
+                    'branch': branch,
+                },
+            },
+            ctx = ctx,
+            remote = remote)
+        (tag, branch, sha1) = buildpackages.get_tag_branch_sha1(gitbuilder)
+        assert tag == None
+        assert branch == expected_branch
+        assert sha1 == expected_sha1
+
+def test_lookup_configs():
+    expected_system_type = 'deb'
+    def make_remote():
+        remote = Mock()
+        remote.arch = 'x86_64'
+        remote.os = Mock()
+        remote.os.name = 'ubuntu'
+        remote.os.version = '14.04'
+        remote.os.codename = 'trusty'
+        remote.system_type = expected_system_type
+        return remote
+    ctx = Mock()
+    class cluster:
+        remote1 = make_remote()
+        remote2 = make_remote()
+        remotes = {
+            remote1: ['client.0'],
+            remote2: ['mon.a','osd.0'],
+        }
+        def only(self, role):
+            result = Mock()
+            if role in ('client.0',):
+                result.remotes = { cluster.remote1: None }
+            elif role in ('osd.0', 'mon.a'):
+                result.remotes = { cluster.remote2: None }
+            else:
+                result.remotes = None
+            return result
+    ctx.cluster = cluster()
+    ctx.config = {
+        'roles': [ ['client.0'], ['mon.a','osd.0'] ],
+    }
+
+    # nothing -> nothing
+    assert buildpackages.lookup_configs(ctx, {}) == []
+    assert buildpackages.lookup_configs(ctx, {1:[1,2,3]}) == []
+    assert buildpackages.lookup_configs(ctx, [[1,2,3]]) == []
+    assert buildpackages.lookup_configs(ctx, None) == []
+
+    #
+    # the overrides applies to install and to install.upgrade
+    # that have no tag, branch or sha1
+    #
+    config = {
+        'overrides': {
+            'install': {
+                'ceph': {
+                    'sha1': 'overridesha1',
+                    'tag': 'overridetag',
+                    'branch': 'overridebranch',
+                },
+            },
+        },
+        'tasks': [
+            {
+                'install': {
+                    'sha1': 'installsha1',
+                },
+            },
+            {
+                'install.upgrade': {
+                    'osd.0': {
+                    },
+                    'client.0': {
+                        'sha1': 'client0sha1',
+                    },
+                },
+            }
+        ],
+    }
+    ctx.config = config
+    expected_configs = [{'branch': 'overridebranch', 'sha1': 'overridesha1', 'tag': 'overridetag'},
+                        {'project': 'ceph', 'branch': 'overridebranch', 'sha1': 'overridesha1', 'tag': 'overridetag'},
+                        {'project': 'ceph', 'sha1': 'client0sha1'}]
+
+    assert buildpackages.lookup_configs(ctx, config) == expected_configs


### PR DESCRIPTION
The install config may have contradicting tag/branch and sha1.  When
suite.py prepares the jobs, it always overrides the sha1 with whatever
default is provided on the command line with --distro and what is found
in the gitbuilder. If it turns out that the tag or the branch in the
install config task is about another sha1, it will override anyway.

Instead of obtaining the tag, branch and sha1 directly from the
packaging.GitbuilderProject object, compute them from the returned
uri_reference data member. The uri_reference is used by the install task
to fetch packages in the gitbuilders and this is what buildpackages
needs to build.

Signed-off-by: Loic Dachary <loic@dachary.org>