### PR TITLE
buildpackages: get ceph submodules

### DIFF
--- a/tasks/buildpackages/make-deb.sh
+++ b/tasks/buildpackages/make-deb.sh
@@ -32,8 +32,7 @@ sudo apt-get install -y git
 
 source $(dirname $0)/common.sh
 
-get_ceph $git_ceph_url $sha1
-install_deps
+init_ceph $git_ceph_url $sha1
 
 #codename=$(lsb_release -sc)
 releasedir=$base/$(lsb_release -si)/WORKDIR

--- a/tasks/buildpackages/make-rpm.sh
+++ b/tasks/buildpackages/make-rpm.sh
@@ -32,8 +32,7 @@ sudo yum install -y git
 
 source $(dirname $0)/common.sh
 
-get_ceph $git_ceph_url $sha1
-install_deps
+init_ceph $git_ceph_url $sha1
 
 #id=$(lsb_release -s -i | tr A-Z a-z)
 #major=$(lsb_release -s -r | sed -s "s;\..*;;g")


### PR DESCRIPTION
Prior to v0.80.9, autogen.sh did not get submodules. Copy/paste the
submodule initialization from newer autogen.sh in common.sh so that
v0.80.8 and below can be rebuilt from sources. It does not hurt to
update the submodules twice.

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit 81f5c3ad0374039280030fba239bf46934584829)