### PR TITLE
openstack: rados/thrash: allocate three disks, always

### DIFF
--- a/suites/rados/thrash/clusters/openstack.yaml
+++ b/suites/rados/thrash/clusters/openstack.yaml
@@ -1,0 +1,8 @@
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 3
+    size: 30 # GB


### PR DESCRIPTION
The thrasher needs disk attached to run against xfs, ext4 or btrfs. And
some jobs use more disks and do not fit in 40GB.

http://tracker.ceph.com/issues/13450 Fixes: #13450

Signed-off-by: Loic Dachary <loic@dachary.org>