### PR TITLE
tasks/admin_socket.py: wait 120 seconds instead of 60

### DIFF
--- a/tasks/admin_socket.py
+++ b/tasks/admin_socket.py
@@ -85,7 +85,7 @@ def _socket_command(ctx, remote, socket_path, command, args):
     """
     json_fp = StringIO()
     testdir = teuthology.get_testdir(ctx)
-    max_tries = 60
+    max_tries = 120
     while True:
         proc = remote.run(
             args=[


### PR DESCRIPTION
When running on virtual machines, it may take more than one minute for a
daemon to create the admin socket.

http://tracker.ceph.com/issues/13449 Fixes: #13449

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit c0828cae19a49d73de02e5cc4a1ac51403b98dec)