### PR TITLE
upgrade/stress-split: needs only six OSDs

### DIFF
--- a/suites/upgrade/hammer-x/stress-split/0-cluster/start.yaml
+++ b/suites/upgrade/hammer-x/stress-split/0-cluster/start.yaml
@@ -11,15 +11,7 @@ roles:
   - osd.0
   - osd.1
   - osd.2
-  - osd.3
+- - osd.3
   - osd.4
   - osd.5
-  - osd.6
-- - osd.7
-  - osd.8
-  - osd.9
-  - osd.10
-  - osd.11
-  - osd.12
-  - osd.13
 - - client.0


### PR DESCRIPTION
The large number of OSDs is only needed for LRC or SHEC in some
cases. All other jobs will do fine with six OSDs.

http://tracker.ceph.com/issues/13408 Fixes: #13408

Signed-off-by: Loic Dachary <loic@dachary.org>