### PR TITLE
rados/singleton-nomsgr/all/msgr: needs 15GB RAM

### DIFF
--- a/suites/rados/singleton-nomsgr/all/msgr.yaml
+++ b/suites/rados/singleton-nomsgr/all/msgr.yaml
@@ -6,3 +6,11 @@ tasks:
     client.0:
           - ceph_test_async_driver
           - ceph_test_msgr
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 15000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 0
+    size: 1 # GB


### PR DESCRIPTION
If given only 8GB RAM,  ceph_test_msgr may abort with buffer::bad_alloc.

http://tracker.ceph.com/issues/11260 Fixes: #11260

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit eac791c664ceed4bd3ac41b0d81ffc337b55e047)