### PR TITLE
rgw: do quota tests on ubuntu

### DIFF
--- a/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
+++ b/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
@@ -1,3 +1,5 @@
+# Amazon/S3.pm (cpan) not available as an rpm
+os_type: ubuntu
 tasks:
 - install:
 - ceph:

--- a/suites/rgw/multifs/tasks/rgw_user_quota.yaml
+++ b/suites/rgw/multifs/tasks/rgw_user_quota.yaml
@@ -1,3 +1,5 @@
+# Amazon/S3.pm (cpan) not available as an rpm
+os_type: ubuntu
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
The Amazon/S3.pm perl module from CPAN is not available as an RPM.

Signed-off-by: Sage Weil <sage@redhat.com>