### PR TITLE
hammer now only supports CentOS 7 and Ubuntu 14.04

### DIFF
--- a/distros/supported/centos_7.0.yaml
+++ b/distros/supported/centos_7.0.yaml
@@ -1,0 +1,1 @@
+../all/centos_7.0.yaml

--- a/distros/supported/debian_7.0.yaml
+++ b/distros/supported/debian_7.0.yaml
@@ -1,1 +1,0 @@
-../all/debian_7.0.yaml

--- a/distros/supported/ubuntu_12.04.yaml
+++ b/distros/supported/ubuntu_12.04.yaml
@@ -1,1 +1,0 @@
-../all/ubuntu_12.04.yaml


### PR DESCRIPTION
Signed-off-by: Loic Dachary <loic@dachary.org>