### PR TITLE
buildpackages: fetch tags from the official Ceph repository

### DIFF
--- a/tasks/buildpackages/common.sh
+++ b/tasks/buildpackages/common.sh
@@ -33,6 +33,7 @@ function get_ceph() {
 
     test -d ceph || git clone ${git_ceph_url}
     cd ceph
+    git fetch --tags http://github.com/ceph/ceph
     git checkout ${sha1}
 }
 


### PR DESCRIPTION
A clone of Ceph is not automagically updated with the tags from the
official Ceph repository. For a pull request based on master, git
describe will use whatever tags existed at the time the clone was made,
unless the author pull them from the official Ceph repository and later
git push --tags them.

The output of git describe is used to name the packages and if the
official tags are not present, the packages will be incorrectly
named. For instance instead of 9.0.3-34 the packages could be named
0.87-8433 because the v0.87 tag is the most recent tag in the
repository. That confuses the install task that will fail with:

   'ceph version 0.87 was not installed, found 9.0.3.'

Signed-off-by: Loic Dachary <ldachary@redhat.com>