### PR TITLE
client-upgrade: hammer-based test should be used on new client

### DIFF
--- a/suites/upgrade/client-upgrade/hammer-client-x/basic/1-install/hammer-client-x.yaml
+++ b/suites/upgrade/client-upgrade/hammer-client-x/basic/1-install/hammer-client-x.yaml
@@ -1,10 +1,10 @@
 tasks:
 - install:
-   branch: hammer 
+    branch: hammer 
 - print: "**** done install hammer"
-- install.upgrade:
-   exclude_packages: ['ceph-test', 'ceph-test-dbg']
-   client.0:
-- print: "**** done install.upgrade client.0"
-- ceph: 
-- print: "**** done ceph"
+upgrade_workload:
+  sequential:
+  - install.upgrade:
+      exclude_packages: ['ceph-test', 'ceph-test-dbg']
+      client.0:
+  - print: "**** done install.upgrade client.0"

--- a/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_api_tests.yaml
+++ b/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_api_tests.yaml
@@ -1,9 +1,21 @@
 tasks:
+- exec:
+    client.0:
+    - "cp $(which ceph_test_librbd_api) $TESTDIR/ceph_test_librbd_api"
+- sequential:
+  - upgrade_workload
+- ceph: 
+- print: "**** done ceph"
+- exec:
+    client.0:
+    - "cp --force $TESTDIR/ceph_test_librbd_api $(which ceph_test_librbd_api)"
+    - "rm -rf $TESTDIR/ceph_test_librbd_api"
+- print: "**** done reverting to hammer ceph_test_librbd_api"
 - workunit:
     branch: hammer
     clients:
       client.0:
-        - rbd/test_librbd_api.sh
+      - rbd/test_librbd_api.sh
     env:
       RBD_FEATURES: "13"
 - print: "**** done rbd/test_librbd_api.sh"

--- a/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_cli_import_export.yaml
+++ b/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_cli_import_export.yaml
@@ -1,9 +1,13 @@
 tasks:
+- sequential:
+  - upgrade_workload
+- ceph: 
+- print: "**** done ceph"
 - workunit:
     branch: hammer
     clients:
       client.0:
-        - rbd/import_export.sh
+      - rbd/import_export.sh
     env:
       RBD_CREATE_ARGS: --new-format
 - print: "**** done rbd/import_export.sh"


### PR DESCRIPTION
Avoid attempting to test new release features that are not available
on older hammer OSDs.

Fixes: #13304
Signed-off-by: Jason Dillaman <dillaman@redhat.com>