### PR TITLE
rados/objectstore/alloc-hint: need three attached disks

### DIFF
--- a/suites/rados/objectstore/alloc-hint.yaml
+++ b/suites/rados/objectstore/alloc-hint.yaml
@@ -15,3 +15,11 @@ tasks:
     clients:
       all:
         - rados/test_alloc_hint.sh
+openstack:
+  machine:
+    disk: 40 # GB
+    ram: 8000 # MB
+    cpus: 1
+  volumes: # attached to each instance
+    count: 3
+    size: 10 # GB


### PR DESCRIPTION
So they can be mkfs xfs.

http://tracker.ceph.com/issues/13451 Fixes: #13451

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit 1a63fd73de3c3de8cff16d486496b1fc5c4cd3b4)