### PR TITLE
rados: 'failed to encode ...' warnings are normal on upgrades

### DIFF
--- a/suites/upgrade/hammer/newer/0-cluster/start.yaml
+++ b/suites/upgrade/hammer/newer/0-cluster/start.yaml
@@ -4,6 +4,7 @@ overrides:
     - scrub
     - scrub mismatch
     - ScrubResult
+    - failed to encode
     fs: xfs
 roles:
 - - mon.a

--- a/suites/upgrade/hammer/newer/4-final/osdthrash.yaml
+++ b/suites/upgrade/hammer/newer/4-final/osdthrash.yaml
@@ -4,6 +4,7 @@ overrides:
     - wrongly marked me down
     - objects unfound and apparently lost
     - log bound mismatch
+    - failed to encode
 tasks:
 - sequential:
   - thrashosds:

--- a/suites/upgrade/hammer/older/0-cluster/start.yaml
+++ b/suites/upgrade/hammer/older/0-cluster/start.yaml
@@ -4,6 +4,7 @@ overrides:
     - scrub
     - scrub mismatch
     - ScrubResult
+    - failed to encode
     fs: xfs
 roles:
 - - mon.a

--- a/suites/upgrade/hammer/older/4-final/osdthrash.yaml
+++ b/suites/upgrade/hammer/older/4-final/osdthrash.yaml
@@ -4,6 +4,7 @@ overrides:
     - wrongly marked me down
     - objects unfound and apparently lost
     - log bound mismatch
+    - failed to encode
 tasks:
 - sequential:
   - thrashosds:

--- a/suites/upgrade/hammer/point-to-point/point-to-point.yaml
+++ b/suites/upgrade/hammer/point-to-point/point-to-point.yaml
@@ -4,6 +4,7 @@ overrides:
     - reached quota
     - scrub
     - osd_map_max_advance
+    - failed to encode
     fs: xfs
     conf:
       mon:


### PR DESCRIPTION
http://tracker.ceph.com/issues/12973 Fixes: #12973

Signed-off-by: Loic Dachary <loic@dachary.org>