### PR TITLE
buildpackages: 10GB is too small most of the time

### DIFF
--- a/tasks/buildpackages.py
+++ b/tasks/buildpackages.py
@@ -178,7 +178,7 @@ def task(ctx, config):
                 select = ''
             build_flavor = openstack.flavor(config['machine'], select)
             http_flavor = openstack.flavor({
-                'disk': 10, # GB
+                'disk': 40, # GB
                 'ram': 1024, # MB
                 'cpus': 1,
             }, select)


### PR DESCRIPTION
Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit 129c5db6c9bc41faa5c52df340776f00ab2db2b6)