### PR TITLE
ceph_manager: do_pg_scrub: keep scrubbing until it's done

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -1378,9 +1378,9 @@ class CephManager:
         Scrub pg and wait for scrubbing to finish
         """
         init = self.get_last_scrub_stamp(pool, pgnum)
-        self.raw_cluster_cmd('pg', stype, self.get_pgid(pool, pgnum))
         while init == self.get_last_scrub_stamp(pool, pgnum):
             self.log("waiting for scrub type %s" % (stype,))
+            self.raw_cluster_cmd('pg', stype, self.get_pgid(pool, pgnum))
             time.sleep(10)
 
     def get_single_pg_stats(self, pgid):


### PR DESCRIPTION
The ceph pg scrub ... command isn't really guarranteed to
start a scrub, keep reissuing it until the scrub actually
happens.

Related: #12746
Signed-off-by: Samuel Just <sjust@redhat.com>