### PR TITLE
openstack: add 30GB for debugging purposes

### DIFF
--- a/debug/openstack-30G.yaml
+++ b/debug/openstack-30G.yaml
@@ -1,0 +1,3 @@
+openstack:
+  - machine:
+      ram: 30000 # MB


### PR DESCRIPTION
So that it can be used as follows:

   teuthology-openstack ... --suite mysuite ... debug/openstack-30G.yaml

Signed-off-by: Loic Dachary <loic@dachary.org>