### PR TITLE
cephfs/test_client_recovery: check fsync waits for unsafe requests

### DIFF
--- a/tasks/cephfs/test_client_recovery.py
+++ b/tasks/cephfs/test_client_recovery.py
@@ -366,7 +366,13 @@ class TestClientRecovery(CephFSTestCase):
             # We killed it, so it raises an error
             pass
 
-    def test_fsync(self):
+    def test_dir_fsync(self):
+	self._test_fsync(True);
+
+    def test_create_fsync(self):
+	self._test_fsync(False);
+
+    def _test_fsync(self, dirfsync):
         """
         That calls to fsync guarantee visibility of metadata to another
         client immediately after the fsyncing client dies.
@@ -382,23 +388,25 @@ class TestClientRecovery(CephFSTestCase):
                 import os
                 import time
 
-                path = "{0}"
+                path = "{path}"
 
                 print "Starting creation..."
                 start = time.time()
 
                 os.mkdir(path)
-                f = open(os.path.join(path, "childfile"), "w")
-                f.close()
-                print "Finished creation in {0}s".format(time.time() - start)
+                dfd = os.open(path, os.O_DIRECTORY)
 
-                fd = os.open(path, os.O_DIRECTORY)
+                fd = open(os.path.join(path, "childfile"), "w")
+                print "Finished creation in {{0}}s".format(time.time() - start)
 
                 print "Starting fsync..."
                 start = time.time()
-                os.fsync(fd)
-                print "Finished fsync in {0}s".format(time.time() - start)
-            """.format(path))
+                if {dirfsync}:
+                    os.fsync(dfd)
+                else:
+                    os.fsync(fd)
+                print "Finished fsync in {{0}}s".format(time.time() - start)
+            """.format(path=path,dirfsync=str(dirfsync)))
         )
 
         # Immediately kill the MDS and then client A


### PR DESCRIPTION
make sure fsync wait for unsafe requests that created/modified the
file.

Signed-off-by: Yan, Zheng <zyan@redhat.com>