### PR TITLE
openstack: add 15GB for debugging purposes

### DIFF
--- a/debug/openstack-15G.yaml
+++ b/debug/openstack-15G.yaml
@@ -1,0 +1,3 @@
+openstack:
+  - machine:
+      ram: 15000 # MB


### PR DESCRIPTION
So that it can be used as follows:

   teuthology-openstack ... --suite mysuite ... debug/openstack-15G.yaml

Signed-off-by: Loic Dachary <loic@dachary.org>