### PR TITLE
task/rbd_fio: allow for unsigned packages

### DIFF
--- a/tasks/rbd_fio.py
+++ b/tasks/rbd_fio.py
@@ -120,7 +120,9 @@ def run_fio(remote, config, rbd_test_dir):
         remote.run(args=['sudo', 'yum' , 'install', 'librbd1-devel', '-y'])
     elif ioengine == 'rbd':
         log.info("Installing librbd devel package on {sn}".format(sn=sn))
-        remote.run(args=['sudo', 'apt-get', '-y', 'install', 'librbd-dev'])
+        remote.run(args=['sudo', 'apt-get', '-y',
+                         '--force-yes',
+                         'install', 'librbd-dev'])
     if ioengine == 'rbd':
         fio_config.write('clientname=admin\n')
         fio_config.write('pool=rbd\n')


### PR DESCRIPTION
Similar to what the teuthology install.py task does, add --force-yes to
the apt-get install so that unsigned packages are successfully
installed. It is needed when the buildpackages task is used to create
packages on the fly.

There is no need to do the same for rpm packages because the
verification is controlled from the ceph-release package instead of from
the command line.

http://tracker.ceph.com/issues/13899 Fixes: #13899

Signed-off-by: Loic Dachary <loic@dachary.org>