### PR TITLE
upgrade/infernalis: run on supported distros

### DIFF
--- a/suites/upgrade/infernalis/point-to-point/distros
+++ b/suites/upgrade/infernalis/point-to-point/distros
@@ -1,0 +1,1 @@
+../../../../distros/supported

--- a/suites/upgrade/infernalis/point-to-point/ubuntu_14.04.yaml
+++ b/suites/upgrade/infernalis/point-to-point/ubuntu_14.04.yaml
@@ -1,1 +1,0 @@
-../../../../distros/supported/ubuntu_14.04.yaml


### PR DESCRIPTION
The upgrade suite is supposed to run on all supported distros.

http://tracker.ceph.com/issues/13908 Fixes: #13908

Signed-off-by: Loic Dachary <loic@dachary.org>