### PR TITLE
buildpackages: create the image if it does not exist

### DIFF
--- a/tasks/buildpackages.py
+++ b/tasks/buildpackages.py
@@ -163,6 +163,7 @@ def task(ctx, config):
             select = '^(vps|eg)-'
         else:
             select = ''
+        openstack.image(os_type, os_version) # create if it does not exist
         build_flavor = openstack.flavor(config['machine'], select)
         http_flavor = openstack.flavor({
             'disk': 40, # GB


### PR DESCRIPTION
Since buildpackages runs before target provisioning, it is possible that
the desired image does not yet exist on a newly provisionned tenant (or
region).

http://tracker.ceph.com/issues/13910 Fixes: #13910

Signed-off-by: Loic Dachary <loic@dachary.org>