### PR TITLE
workunits: fetch from --ceph-git-url

### DIFF
--- a/suites/teuthology/workunits/yes.yaml
+++ b/suites/teuthology/workunits/yes.yaml
@@ -1,0 +1,8 @@
+roles:
+    - [client.0]
+tasks:
+- install:
+- workunit:
+    clients:
+      all:
+        - true.sh

--- a/tasks/workunit.py
+++ b/tasks/workunit.py
@@ -312,9 +312,8 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         ],
     )
 
-    workunits = sorted(misc.get_file(
-        remote,
-        '{tdir}/workunits.list.{role}'.format(tdir=testdir, role=role)).split('\0'))
+    workunits_file = '{tdir}/workunits.list.{role}'.format(tdir=testdir, role=role)
+    workunits = sorted(misc.get_file(remote, workunits_file).split('\0'))
     assert workunits
 
     try:
@@ -369,6 +368,6 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(
             logger=log.getChild(role),
             args=[
-                'rm', '-rf', '--', '{tdir}/workunits.list.{role}'.format(tdir=testdir, role=role), srcdir,
+                'rm', '-rf', '--', workunits_file, srcdir,
             ],
         )

--- a/tasks/workunit.py
+++ b/tasks/workunit.py
@@ -70,9 +70,9 @@ def task(ctx, config):
 
     refspec = config.get('branch')
     if refspec is None:
-        refspec = config.get('sha1')
-    if refspec is None:
         refspec = config.get('tag')
+    if refspec is None:
+        refspec = config.get('sha1')
     if refspec is None:
         refspec = 'HEAD'
 

--- a/tasks/workunit.py
+++ b/tasks/workunit.py
@@ -6,6 +6,7 @@ import pipes
 import os
 
 from teuthology import misc
+from teuthology.config import config as teuth_config
 from teuthology.orchestra.run import CommandFailedError
 from teuthology.parallel import parallel
 from teuthology.orchestra import run
@@ -287,22 +288,46 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
     else:
         scratch_tmp = os.path.join(mnt, subdir)
     srcdir = '{tdir}/workunit.{role}'.format(tdir=testdir, role=role)
+    clonedir = '{tdir}/clone'.format(tdir=testdir)
+
+    git_url = teuth_config.get_ceph_git_url()
+    if 'github.com/ceph/ceph' in git_url:
+        remote.run(
+            logger=log.getChild(role),
+            args=[
+                'mkdir', '--', srcdir,
+                run.Raw('&&'),
+                'git',
+                'archive',
+                '--remote=git://git.ceph.com/ceph.git',
+                '%s:qa/workunits' % refspec,
+                run.Raw('|'),
+                'tar',
+                '-C', srcdir,
+                '-x',
+                '-f-',
+            ],
+        )
+    else:
+        remote.run(
+            logger=log.getChild(role),
+            args=[
+                'git',
+                'clone',
+                git_url,
+                clonedir,
+                run.Raw(';'),
+                'cd', '--', clonedir,
+                run.Raw('&&'),
+                'git', 'reset', '--hard', refspec,
+                run.Raw('&&'),
+                'mv', 'qa/workunits', srcdir,
+            ],
+        )
 
     remote.run(
         logger=log.getChild(role),
         args=[
-            'mkdir', '--', srcdir,
-            run.Raw('&&'),
-            'git',
-            'archive',
-            '--remote=git://git.ceph.com/ceph.git',
-            '%s:qa/workunits' % refspec,
-            run.Raw('|'),
-            'tar',
-            '-C', srcdir,
-            '-x',
-            '-f-',
-            run.Raw('&&'),
             'cd', '--', srcdir,
             run.Raw('&&'),
             'if', 'test', '-e', 'Makefile', run.Raw(';'), 'then', 'make', run.Raw(';'), 'fi',
@@ -368,6 +393,6 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(
             logger=log.getChild(role),
             args=[
-                'rm', '-rf', '--', workunits_file, srcdir,
+                'rm', '-rf', '--', workunits_file, srcdir, clonedir,
             ],
         )


### PR DESCRIPTION
The commit from which workunits must be fetched must be retrieved
from --ceph-git-url via teuth_config.get_ceph_git_url() instead of
assuming it is available via git://git.ceph.com/ceph.git.

Assuming git://git.ceph.com/ceph.git is convenient because it
supports git archive. In the general case, some git servers such as
github do not support git archive and a full git clone must be done.

Although it would be possible to

   git clone --branch=master --depth=1 --single-branch

to reduce the amount of data being retrieved, it would require a

   git fetch origin SHA1

but git version >= 1.7 require a refspec and do not support fetching
a commit.

http://tracker.ceph.com/issues/13624 Fixes: #13624

Signed-off-by: Loic Dachary <loic@dachary.org>