### PR TITLE
Fix runs on OpenStack clusters like DreamHost Compute

### DIFF
--- a/tasks/buildpackages/Makefile
+++ b/tasks/buildpackages/Makefile
@@ -1,6 +1,10 @@
 SHELL=/bin/bash
 D=/tmp/stampsdir
 VPATH=${D}
+PKG_REPO=packages-repository
+PKG_REPO_OS_TYPE=ubuntu
+PKG_REPO_OS_VERSION=14.04
+PKG_REPO_USER_DATA=${PKG_REPO_OS_TYPE}-${PKG_REPO_OS_VERSION}-user-data.txt
 
 # We want to extract the first listed IPv4 address!
 # Openstack will provide the addresses field in this format:
@@ -25,22 +29,24 @@ ${HOME}/.ssh_agent:
 	source ${HOME}/.ssh_agent ; ssh-add ; ssh-add -l
 	grep -q ssh_agent ~/.bashrc_teuthology || echo 'source ${HOME}/.ssh_agent' >> ~/.bashrc_teuthology
 
-flock-packages-repository:
-	openstack server create --image 'teuthology-ubuntu-14.04' --flavor ${HTTP_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --wait packages-repository
+flock-${PKG_REPO}:
+	openstack server create --image 'teuthology-ubuntu-14.04' --flavor ${HTTP_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${PKG_REPO_USER_DATA} --wait ${PKG_REPO}
 	sleep 30
-	ip=$(call get_ip,packages-repository) ; \
+	set -ex ; \
+	ip=$(call get_ip,${PKG_REPO}) ; \
+	for delay in 1 2 4 8 8 8 8 8 8 8 8 8 16 16 16 16 16 32 32 32 64 128 256 512 ; do if ssh -o 'ConnectTimeout=3' $$ip bash -c '"grep -q READYTORUN /var/log/cloud-init*.log"' ; then break ; else sleep $$delay ; fi ; done ; \
 	ssh $$ip sudo apt-get update ; \
-	ssh $$ip sudo apt-get install -y nginx ; \
-	ssh $$ip sudo chown -R ubuntu /usr/share/nginx/html ; \
+	ssh $$ip sudo apt-get install -y nginx && \
+	ssh $$ip sudo chown -R ubuntu /usr/share/nginx/html && \
 	perl -pi -e "s/^gitbuilder_host:.*/gitbuilder_host: $$ip/" ~/.teuthology.yaml
 	touch ${D}/$@
 
-packages-repository:
+${PKG_REPO}:
 	mkdir -p ${D}
 	flock --close ${D}/flock-$@.lock ${MAKE} flock-$@
 	touch ${D}/$@
 
-ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-${CEPH_FLAVOR}-${CEPH_SHA1}: packages-repository
+ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-${CEPH_FLAVOR}-${CEPH_SHA1}: ${PKG_REPO}
 	openstack server create --image 'teuthology-${CEPH_OS_TYPE}-${CEPH_OS_VERSION}' --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@
 	sleep 30
 	set -ex ; \

--- a/tasks/buildpackages/Makefile
+++ b/tasks/buildpackages/Makefile
@@ -2,8 +2,20 @@ SHELL=/bin/bash
 D=/tmp/stampsdir
 VPATH=${D}
 
+# We want to extract the first listed IPv4 address!
+# Openstack will provide the addresses field in this format:
+# "net1-name=ip(, ip)+(; net2-name=ip(, ip)+)+"
+# Each IP may be v4 or v6 (including shortened forms and IPv4-mapped-IPv6 forms)
+# 1.2.3.4
+# 2001:db8:6050:ed4d:f816:3eff:fe48:3b36
+# 2001:db8::fe48:3b36
+# 2001:db8::1.2.3.4
+# Example long-form input:
+# private-network=10.10.10.69, 2001:db8:6050:ed4d:f816:3eff:fed1:d9f8;net-name2=2001:db8::fe48:3b36, 2001:db8::1.2.3.4, 1.2.3.4;
+# TODO: allow selection of the network instead of taking the first network
+# TODO: Support IPv6 in future
 define get_ip
-$$(openstack server show -f json $(1) | jq '.[] | select(.Field == "addresses") | .Value' | perl -pe 's/([\da-f]*:){7}[\da-f]*, //; s/.*?=([\d\.]+).*/$$1/')
+$$(openstack server show -f value -c addresses $(1) |perl -pe 's/^[^=]+=([^;]+).*/\1/g; s/[ ,]/\n/g; ' |grep -v -e ':' -e '^$$' |head -n1)
 endef
 
 MY_IP=$(shell hostname -I | cut -f1 -d' ')

--- a/tasks/buildpackages/Makefile
+++ b/tasks/buildpackages/Makefile
@@ -26,7 +26,8 @@ ${HOME}/.ssh_agent:
 	grep -q ssh_agent ~/.bashrc_teuthology || echo 'source ${HOME}/.ssh_agent' >> ~/.bashrc_teuthology
 
 flock-packages-repository:
-	openstack server create --image 'teuthology-ubuntu-14.04' --flavor ${HTTP_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --wait packages-repository ; sleep 30
+	openstack server create --image 'teuthology-ubuntu-14.04' --flavor ${HTTP_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --wait packages-repository
+	sleep 30
 	ip=$(call get_ip,packages-repository) ; \
 	ssh $$ip sudo apt-get update ; \
 	ssh $$ip sudo apt-get install -y nginx ; \
@@ -40,7 +41,8 @@ packages-repository:
 	touch ${D}/$@
 
 ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-${CEPH_FLAVOR}-${CEPH_SHA1}: packages-repository
-	openstack server create --image 'teuthology-${CEPH_OS_TYPE}-${CEPH_OS_VERSION}' --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@ ; sleep 30
+	openstack server create --image 'teuthology-${CEPH_OS_TYPE}-${CEPH_OS_VERSION}' --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@
+	sleep 30
 	set -ex ; \
 	trap "openstack server delete --wait $@" EXIT ; \
 	ip=$(call get_ip,$@) ; \

--- a/tasks/buildpackages/user-data.txt
+++ b/tasks/buildpackages/user-data.txt
@@ -1,4 +1,9 @@
 #cloud-config
+bootcmd:
+ - echo 'APT::Get::AllowUnauthenticated "true";' | tee /etc/apt/apt.conf.d/99disablesigs
+ - echo nameserver 8.8.8.8 | sudo tee -a /etc/resolv.conf # last resort, in case the DHCP server does not provide a resolver
+manage_etc_hosts: true
+preserve_hostname: true
 system_info:
   default_user:
     name: ubuntu


### PR DESCRIPTION
This fixes ceph-qa-suite to run successfully on the DreamHost Compute Openstack environment. It does less setup of VM networking, so we need to merge similar changes that were made to teuthology.
