### PR TITLE
buildpackages: openstack image names not unique.

### DIFF
--- a/tasks/buildpackages.py
+++ b/tasks/buildpackages.py
@@ -167,8 +167,15 @@ def task(ctx, config):
             'ram': 1024, # MB
             'cpus': 1,
         }, select)
+        lockname = "/tmp/buildpackages-{sha1}-{pkg_type}-{os_type}-{os_version}-{arch}".format(
+                pkg_type=pkg_type,
+                os_type=os_type,
+                os_version=os_version,
+                arch=arch,
+                sha1=sha1,
+                )
         cmd = (". " + os.environ['HOME'] + "/.ssh_agent ; " +
-               " flock --close /tmp/buildpackages-" + sha1 +
+               " flock --close " + lockname +
                " make -C " + d +
                " CEPH_GIT_URL=" + teuth_config.get_ceph_git_url() +
                " CEPH_PKG_TYPE=" + pkg_type +

--- a/tasks/buildpackages/Makefile
+++ b/tasks/buildpackages/Makefile
@@ -1,6 +1,8 @@
 SHELL=/bin/bash
 D=/tmp/stampsdir
 VPATH=${D}
+TIMEOUT_SERVER_CREATE = 30m
+TIMEOUT_BUILD = 220m # 20 minutes short of 4 hours
 PKG_REPO=packages-repository
 PKG_REPO_OS_TYPE=ubuntu
 PKG_REPO_OS_VERSION=14.04
@@ -48,7 +50,7 @@ ${HOME}/.ssh_agent:
 	grep -q ssh_agent ~/.bashrc_teuthology || echo 'source ${HOME}/.ssh_agent' >> ~/.bashrc_teuthology
 
 flock-${PKG_REPO}:
-	openstack server create --image ${PKG_REPO_IMAGE_ID} --flavor ${HTTP_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${PKG_REPO_USER_DATA} --wait ${PKG_REPO}
+	timeout $(TIMEOUT_SERVER_CREATE) openstack server create --image ${PKG_REPO_IMAGE_ID} --flavor ${HTTP_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${PKG_REPO_USER_DATA} --wait ${PKG_REPO}
 	sleep 30
 	set -ex ; \
 	ip=$(call get_ip,${PKG_REPO}) ; \
@@ -69,7 +71,7 @@ ${PKG_REPO}:
 # If it's a weird status, bail out and let the delete fire
 # eg: ERROR status can happen if there is no VM host without enough capacity for the request.
 ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-${CEPH_FLAVOR}-${CEPH_SHA1}: ${PKG_REPO}
-	openstack server create --image ${BUILD_IMAGE_ID} --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@
+	timeout $(TIMEOUT_SERVER_CREATE) openstack server create --image ${BUILD_IMAGE_ID} --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@
 	set -ex ; \
 	trap "openstack server delete --wait $@" EXIT ; \
 	for delay in 10 10 10 ; do \
@@ -85,7 +87,7 @@ ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-${CEPH_FLAVOR}-${CEPH_SHA1}: ${P
 	for delay in 1 2 4 8 8 8 8 8 8 8 8 8 16 16 16 16 16 32 32 32 64 128 256 512 ; do if ssh -o 'ConnectTimeout=3' $$ip bash -c '"grep -q READYTORUN /var/log/cloud-init*.log"' ; then break ; else sleep $$delay ; fi ; done ; \
 	scp make-${CEPH_PKG_TYPE}.sh common.sh ubuntu@$$ip: ; \
 	packages_repository=$(call get_ip,${<F}) ; \
-	ssh -tt -A ubuntu@$$ip bash ./make-${CEPH_PKG_TYPE}.sh $$packages_repository ${CEPH_DIST} ${CEPH_GIT_URL} ${CEPH_SHA1} ${CEPH_FLAVOR}
+	timeout $(TIMEOUT_BUILD) ssh -tt -A ubuntu@$$ip bash ./make-${CEPH_PKG_TYPE}.sh $$packages_repository ${CEPH_DIST} ${CEPH_GIT_URL} ${CEPH_SHA1} ${CEPH_FLAVOR}
 	mkdir -p ${D}/${@D} ; touch ${D}/$@
 
 clobber:

--- a/tasks/buildpackages/Makefile
+++ b/tasks/buildpackages/Makefile
@@ -64,12 +64,24 @@ ${PKG_REPO}:
 	flock --close ${D}/flock-$@.lock ${MAKE} flock-$@
 	touch ${D}/$@
 
+# Just because 'server create' return success does not mean it actually succeeded!
+# Check the server status before we proceed.
+# If it's a weird status, bail out and let the delete fire
+# eg: ERROR status can happen if there is no VM host without enough capacity for the request.
 ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-${CEPH_FLAVOR}-${CEPH_SHA1}: ${PKG_REPO}
 	openstack server create --image ${BUILD_IMAGE_ID} --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@
-	sleep 30
 	set -ex ; \
 	trap "openstack server delete --wait $@" EXIT ; \
+	for delay in 10 10 10 ; do \
+		status=$$(openstack server show -c status -f value $@) ; \
+		case $$status in \
+			ACTIVE) break ;; \
+			NOSTATE|*BUILD|*BOOT|*RESIZE) sleep $$delay ;; \
+			*) exit 1 ;; \
+		esac ; \
+	done ; \
 	ip=$(call get_ip,$@) ; \
+	test -n "$$ip" || exit ; \
 	for delay in 1 2 4 8 8 8 8 8 8 8 8 8 16 16 16 16 16 32 32 32 64 128 256 512 ; do if ssh -o 'ConnectTimeout=3' $$ip bash -c '"grep -q READYTORUN /var/log/cloud-init*.log"' ; then break ; else sleep $$delay ; fi ; done ; \
 	scp make-${CEPH_PKG_TYPE}.sh common.sh ubuntu@$$ip: ; \
 	packages_repository=$(call get_ip,${<F}) ; \

--- a/tasks/buildpackages/Makefile
+++ b/tasks/buildpackages/Makefile
@@ -6,6 +6,24 @@ PKG_REPO_OS_TYPE=ubuntu
 PKG_REPO_OS_VERSION=14.04
 PKG_REPO_USER_DATA=${PKG_REPO_OS_TYPE}-${PKG_REPO_OS_VERSION}-user-data.txt
 
+# The --property filter does NOT get applied multiple times.
+# So we must do the work ourselves.
+# It is still possible that there are multiple images with the same name, so we
+# take the first one after that.
+# Filters:
+# 1: Owner, as depending on OpenStack permissions, you can see multiple owner's images
+# 2: Name of image
+define get_image_id
+$$(openstack image list -f json --long \
+	| jq -r '.[] | select(.Owner == "$(OS_TENANT_ID)" and .Name == "$(1)") | .ID' \
+	| head -n1 )
+endef
+
+PKG_REPO_IMAGE_NAME=teuthology-${PKG_REPO_OS_TYPE}-${PKG_REPO_OS_VERSION}
+PKG_REPO_IMAGE_ID=$(call get_image_id,$(PKG_REPO_IMAGE_NAME))
+BUILD_IMAGE_NAME=teuthology-${CEPH_OS_TYPE}-${CEPH_OS_VERSION}
+BUILD_IMAGE_ID=$(call get_image_id,$(BUILD_IMAGE_NAME))
+
 # We want to extract the first listed IPv4 address!
 # Openstack will provide the addresses field in this format:
 # "net1-name=ip(, ip)+(; net2-name=ip(, ip)+)+"
@@ -30,7 +48,7 @@ ${HOME}/.ssh_agent:
 	grep -q ssh_agent ~/.bashrc_teuthology || echo 'source ${HOME}/.ssh_agent' >> ~/.bashrc_teuthology
 
 flock-${PKG_REPO}:
-	openstack server create --image 'teuthology-ubuntu-14.04' --flavor ${HTTP_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${PKG_REPO_USER_DATA} --wait ${PKG_REPO}
+	openstack server create --image ${PKG_REPO_IMAGE_ID} --flavor ${HTTP_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${PKG_REPO_USER_DATA} --wait ${PKG_REPO}
 	sleep 30
 	set -ex ; \
 	ip=$(call get_ip,${PKG_REPO}) ; \
@@ -47,7 +65,7 @@ ${PKG_REPO}:
 	touch ${D}/$@
 
 ceph-${CEPH_PKG_TYPE}-${CEPH_DIST}-${CEPH_ARCH}-${CEPH_FLAVOR}-${CEPH_SHA1}: ${PKG_REPO}
-	openstack server create --image 'teuthology-${CEPH_OS_TYPE}-${CEPH_OS_VERSION}' --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@
+	openstack server create --image ${BUILD_IMAGE_ID} --flavor ${BUILD_FLAVOR} --key-name teuthology --security-group teuthology --property ownedby=${MY_IP} --user-data ${CEPH_OS_TYPE}-${CEPH_OS_VERSION}-user-data.txt --wait $@
 	sleep 30
 	set -ex ; \
 	trap "openstack server delete --wait $@" EXIT ; \

--- a/tasks/buildpackages/make-deb.sh
+++ b/tasks/buildpackages/make-deb.sh
@@ -68,10 +68,17 @@ function build_package() {
     # options (otherwise parts of the source tree will be left out).
     #
     ./autogen.sh
+	# Building with LTTNG on Ubuntu Precise is not possible.
+	# It fails the LTTNG-is-sane check (it misses headers)
+	# And the Debian rules files leave it out anyway
+	case $codename in
+		precise) lttng_opt="--without-lttng" ;;
+		*) lttng_opt="--with-lttng" ;;
+	esac
     ./configure $(flavor2configure $flavor) \
         --with-rocksdb --with-ocf \
         --with-nss --with-debug --enable-cephfs-java \
-        --with-lttng --with-babeltrace
+        $lttng_opt --with-babeltrace
     #
     # use distdir= to set the name of the top level directory of the
     # tarbal to match the desired version

--- a/tasks/buildpackages/ubuntu-12.04-user-data.txt
+++ b/tasks/buildpackages/ubuntu-12.04-user-data.txt
@@ -1,0 +1,1 @@
+user-data.txt


### PR DESCRIPTION
OpenStack image names are not always unique, as noted by teuthology
commit d4c98512: openstack: image names only unique within tenants

Use the unique image ID to create the pkg host and the build hosts
instead (server create fails otherwise).

Signed-off-by: Robin H. Johnson robin.johnson@dreamhost.com
