### PR TITLE
rados: run radosbench for 15m instead of 30m

### DIFF
--- a/suites/rados/thrash-erasure-code/workloads/ec-radosbench.yaml
+++ b/suites/rados/thrash-erasure-code/workloads/ec-radosbench.yaml
@@ -1,6 +1,6 @@
 tasks:
 - radosbench:
     clients: [client.0]
-    time: 1800
+    time: 900
     unique_pool: true
     ec_pool: true

--- a/suites/rados/thrash/workloads/radosbench.yaml
+++ b/suites/rados/thrash/workloads/radosbench.yaml
@@ -8,4 +8,4 @@ overrides:
 tasks:
 - radosbench:
     clients: [client.0]
-    time: 1800
+    time: 900

--- a/suites/rados/upgrade/hammer-x-singleton/7-workload/radosbench.yaml
+++ b/suites/rados/upgrade/hammer-x-singleton/7-workload/radosbench.yaml
@@ -1,5 +1,5 @@
 tasks:
 - radosbench:
     clients: [client.0]
-    time: 1800
+    time: 900
 - print: "**** done radosbench 7-workload"


### PR DESCRIPTION
The smithi disks fill after about 20m.

Signed-off-by: Sage Weil <sage@redhat.com>