### PR TITLE
tasks/cephfs: better message from test_full_fsync

### DIFF
--- a/tasks/cephfs/test_full.py
+++ b/tasks/cephfs/test_full.py
@@ -314,7 +314,12 @@ class FullnessTestCase(CephFSTestCase):
             full = False
 
             for n in range(0, {fill_mb} + 1):
-                bytes += os.write(f, 'x' * 1024 * 1024)
+                try:
+                    bytes += os.write(f, 'x' * 1024 * 1024)
+                except OSError as e:
+                    print "Unexpected error %s from write() instead of fsync()" % e
+                    raise
+
                 try:
                     os.fsync(f)
                 except OSError as e:


### PR DESCRIPTION
When it gives an error from the unexpected place,
say so.

Signed-off-by: John Spray <john.spray@redhat.com>