### PR TITLE
tasks/cephfs: check status asok output while in reconnect

### DIFF
--- a/tasks/cephfs/test_client_recovery.py
+++ b/tasks/cephfs/test_client_recovery.py
@@ -143,6 +143,9 @@ class TestClientRecovery(CephFSTestCase):
         self.fs.mds_restart()
 
         self.fs.wait_for_state('up:reconnect', reject='up:active', timeout=MDS_RESTART_GRACE)
+        # Check that the MDS locally reports its state correctly
+        status = self.fs.mds_asok(['status'])
+        self.assertIn("reconnect_status", status)
 
         ls_data = self._session_list()
         self.assert_session_count(2, ls_data)


### PR DESCRIPTION
Mostly checking the output from the status asok is awkward
because you need to get the system stuck in a particular
state to do so.  However, we already have a test here
that sticks the system in reconnect, so here's some
very light test coverage for that asok.

Signed-off-by: John Spray <john.spray@redhat.com>