### PR TITLE
suites/rbd: avoid redundant helgrind tests

### DIFF
--- a/suites/rbd/valgrind/validator/helgrind.yaml
+++ b/suites/rbd/valgrind/validator/helgrind.yaml
@@ -1,4 +1,6 @@
 overrides:
+  rbd_fsx:
+    valgrind: ["--tool=helgrind"]
   workunit:
     env:
       VALGRIND: "helgrind"

--- a/suites/rbd/valgrind/validator/memcheck.yaml
+++ b/suites/rbd/valgrind/validator/memcheck.yaml
@@ -1,4 +1,6 @@
 overrides:
+  rbd_fsx:
+    valgrind: ["--tool=memcheck"]
   workunit:
     env:
       VALGRIND: "memcheck"

--- a/suites/rbd/valgrind/workloads/fsx.yaml
+++ b/suites/rbd/valgrind/workloads/fsx.yaml
@@ -2,4 +2,3 @@ tasks:
 - rbd_fsx:
     clients: [client.0]
     size: 134217728
-    valgrind: [--tool=memcheck]

--- a/suites/rbd/valgrind/workloads/fsx_helgrind.yaml
+++ b/suites/rbd/valgrind/workloads/fsx_helgrind.yaml
@@ -1,5 +1,0 @@
-tasks:
-- rbd_fsx:
-    clients: [client.0]
-    size: 134217728
-    valgrind: [--tool=helgrind]

--- a/tasks/rbd_fsx.py
+++ b/tasks/rbd_fsx.py
@@ -33,6 +33,7 @@ def task(ctx, config):
           seed: <random seed number, or 0 to use the time>
           ops: <number of operations to do>
           size: <maximum image size in bytes>
+          valgrind: [--tool=<valgrind tool>]
     """
     log.info('starting rbd_fsx...')
     with parallel() as p:
@@ -54,6 +55,9 @@ def _run_one_client(ctx, config, role):
         'ceph-coverage',
         '{tdir}/archive/coverage'.format(tdir=testdir)
     ])
+
+    overrides = ctx.config.get('overrides', {})
+    teuthology.deep_merge(config, overrides.get('rbd_fsx', {}))
 
     if config.get('valgrind'):
         args = teuthology.get_valgrind_args(


### PR DESCRIPTION
Allow rbd_fsx to accept an override for which valgrind tool to use.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>