### PR TITLE
Fixes issue #14389

### DIFF
--- a/suites/upgrade/firefly-hammer-x/parallel/0-cluster/start.yaml
+++ b/suites/upgrade/firefly-hammer-x/parallel/0-cluster/start.yaml
@@ -8,6 +8,7 @@ overrides:
       - scrub mismatch
       - ScrubResult
       - failed to encode map
+      - wrongly marked me down
 roles:
 - - mon.a
   - mds.a

--- a/suites/upgrade/infernalis/older/0-cluster/start.yaml
+++ b/suites/upgrade/infernalis/older/0-cluster/start.yaml
@@ -12,6 +12,7 @@ overrides:
     - wrongly marked me down
     - objects unfound and apparently lost
     - log bound mismatch
+    - failed to encode map
     - soft lockup
     fs: xfs
 roles:

--- a/suites/upgrade/infernalis/older/1-install/latest_hammer_release.yaml
+++ b/suites/upgrade/infernalis/older/1-install/latest_hammer_release.yaml
@@ -1,13 +1,13 @@
 meta:
 - desc: |
-   install ceph/infernalis
+   install ceph/hammer latest release
    run workload and upgrade-sequence in parallel
 tasks:
 - install:
-    branch: infernalis
-- print: "**** done latest infernalis install"
+    branch: hammer
+- print: "**** done latest hammer install"
 - ceph:
 - parallel:
    - workload
    - upgrade-sequence
-- print: "**** done parallel infernalis"
+- print: "**** done parallel hammer"

--- a/suites/upgrade/infernalis/older/1-install/v9.2.0.yaml
+++ b/suites/upgrade/infernalis/older/1-install/v9.2.0.yaml
@@ -1,13 +1,13 @@
 meta:
 - desc: |
-   install ceph/infernalis v9.1.0
+   install ceph/infernalis v9.2.0
    run workload and upgrade-sequence in parallel
 tasks:
 - install:
-    tag: v9.1.0
-- print: "**** done v9.1.0 install"
+    tag: v9.2.0
+- print: "**** done v9.2.0 install"
 - ceph:
 - parallel:
    - workload
    - upgrade-sequence
-- print: "**** done parallel v9.1.0"
+- print: "**** done parallel v9.2.0"

--- a/suites/upgrade/infernalis/older/2-workload/s3tests.yaml
+++ b/suites/upgrade/infernalis/older/2-workload/s3tests.yaml
@@ -1,0 +1,11 @@
+meta:
+- desc: |
+   add test details here
+   run s3tests
+workload:
+  sequential:
+  - rgw: [client.0]
+  - s3tests:
+      client.0:
+        force-branch: hammer
+        rgw_server: client.0

--- a/suites/upgrade/infernalis/older/2-workload/testrados.yaml
+++ b/suites/upgrade/infernalis/older/2-workload/testrados.yaml
@@ -2,14 +2,15 @@ meta:
 - desc: |
    run randomized correctness test for rados operations
 workload:
-  rados:
-    clients: [client.0]
-    ops: 2000
-    objects: 50
-    op_weights:
-      read: 100
-      write: 100
-      delete: 50
-      snap_create: 50
-      snap_remove: 50
-      rollback: 50
+  sequential:
+     - rados:
+         clients: [client.0]
+         ops: 2000
+         objects: 50
+         op_weights:
+           read: 100
+           write: 100
+           delete: 50
+           snap_create: 50
+           snap_remove: 50
+           rollback: 50


### PR DESCRIPTION
@liewegas 
@tmuthamizhan 

Added s3tests workload
Fixed initial version to be 'hammer'
Added v9.2.0 to the mix

Note: whitelisted 'failed to encode map'

@tmuthamizhan I removed v9.1.0.yaml as it looks like only v9.2.0 was officially infernalis release, but need you to confirm this assessment.

(added `+` to run all workloads together sequentially )

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>