### PR TITLE
rbd: rbd-nbd can only run on Ubuntu

### DIFF
--- a/suites/rbd/thrash/workloads/rbd_nbd.yaml
+++ b/suites/rbd/thrash/workloads/rbd_nbd.yaml
@@ -1,3 +1,4 @@
+os_type: ubuntu
 overrides:
   install:
     ceph:


### PR DESCRIPTION
NBD support is not available in RHEL/CentOS 7

Signed-off-by: Jason Dillaman <dillaman@redhat.com>