### PR TITLE
Made disk size in openstack 40GB, so osd won't run out of space

### DIFF
--- a/suites/upgrade/hammer-x/stress-split/0-cluster/openstack.yaml
+++ b/suites/upgrade/hammer-x/stress-split/0-cluster/openstack.yaml
@@ -1,0 +1,3 @@
+openstack:
+  - machine:
+      disk: 40 # GB


### PR DESCRIPTION
@dachary Fixed per comments in https://github.com/ceph/ceph-qa-suite/pull/806

Signed-off-by: Yuri Weinstein yweinste@redhat.com
