### PR TITLE
tasks/cephfs: fix race in test_damage

### DIFF
--- a/tasks/cephfs/test_damage.py
+++ b/tasks/cephfs/test_damage.py
@@ -203,9 +203,14 @@ class TestDamage(CephFSTestCase):
             self.fs.mds_restart()
 
             if mutation.expectation not in (DAMAGED_ON_LS, NO_DAMAGE):
+                # MDS may go to damaged state after coming up. Wait for damaged state first
+                try:
+                    self.wait_until_true(lambda: self.is_marked_damaged(0), 60)
+                except RuntimeError:
+                    pass
                 # Wait for MDS to either come up or go into damaged state
                 try:
-                    self.wait_until_true(lambda: self.is_marked_damaged(0) or self.fs.are_daemons_healthy(), 60)
+                    self.wait_until_true(lambda: self.is_marked_damaged(0) or self.fs.are_daemons_healthy(), 10)
                 except RuntimeError:
                     crashed = False
                     # Didn't make it to healthy or damaged, did it crash?


### PR DESCRIPTION
When stray directory inodes are corrupted, MDS may go to damaged state
after becoming active. (MDCache::open_root/populate_mydir is called by
MDSRank::starting_done).

Fixes: #14196
Signed-off-by: Yan, Zheng <zyan@redhat.com>
(cherry picked from commit b2a304e651b60ad0556fcf7fa77e753fde39e81c)