### PR TITLE
cram: pin to version 0.6 because 0.7 handles \r differently

### DIFF
--- a/tasks/cram.py
+++ b/tasks/cram.py
@@ -60,7 +60,7 @@ def task(ctx, config):
                     'virtualenv', '{tdir}/virtualenv'.format(tdir=testdir),
                     run.Raw('&&'),
                     '{tdir}/virtualenv/bin/pip'.format(tdir=testdir),
-                    'install', 'cram',
+                    'install', 'cram==0.6',
                     ],
                 )
             for test in tests:


### PR DESCRIPTION
Signed-off-by: Loic Dachary <loic@dachary.org>