### PR TITLE
cram: pin to version 0.6 because 0.7 handles \r differently

### DIFF
--- a/tasks/cram.py
+++ b/tasks/cram.py
@@ -60,7 +60,7 @@ def task(ctx, config):
                     'virtualenv', '{tdir}/virtualenv'.format(tdir=testdir),
                     run.Raw('&&'),
                     '{tdir}/virtualenv/bin/pip'.format(tdir=testdir),
-                    'install', 'cram',
+                    'install', 'cram==0.6',
                     ],
                 )
             for test in tests:


### PR DESCRIPTION
http://tracker.ceph.com/issues/14931 Fixes: #14931

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit 70fb7493f18c45b93d6065c03403c5dd478295f3)