### PR TITLE
ceph-ansible: Add openstack hints for volumes

### DIFF
--- a/suites/ceph-ansible/smoke/2-setup/ceph_ansible.yaml
+++ b/suites/ceph-ansible/smoke/2-setup/ceph_ansible.yaml
@@ -13,3 +13,7 @@ overrides:
   ceph_ansible:
     vars:
       ceph_test: true
+openstack:
+  - volumes:
+      count: 3
+      size: 20  # GB


### PR DESCRIPTION
3x20GB per instance

Signed-off-by: Zack Cerza <zack@redhat.com>