### PR TITLE
tasks/ceph_manager: dump pgs if other peering timeouts expire

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -1582,8 +1582,12 @@ class CephManager:
                     start = time.time()
                 else:
                     self.log("no progress seen, keeping timeout for now")
-                    assert time.time() - start < timeout, \
-                        'failed to become clean before timeout expired'
+                    if time.time() - start >= timeout:
+                        self.log('dumping pgs')
+                        out = self.raw_cluster_cmd('pg', 'dump')
+                        self.log(out)
+                        assert time.time() - start < timeout, \
+                            'failed to become clean before timeout expired'
             cur_active_clean = self.get_num_active_clean()
             if cur_active_clean != num_active_clean:
                 start = time.time()
@@ -1649,8 +1653,12 @@ class CephManager:
         num_active = self.get_num_active()
         while not self.is_active():
             if timeout is not None:
-                assert time.time() - start < timeout, \
-                    'failed to recover before timeout expired'
+                if time.time() - start >= timeout:
+                    self.log('dumping pgs')
+                    out = self.raw_cluster_cmd('pg', 'dump')
+                    self.log(out)
+                    assert time.time() - start < timeout, \
+                        'failed to recover before timeout expired'
             cur_active = self.get_num_active()
             if cur_active != num_active:
                 start = time.time()
@@ -1668,8 +1676,12 @@ class CephManager:
         num_active_down = self.get_num_active_down()
         while not self.is_active_or_down():
             if timeout is not None:
-                assert time.time() - start < timeout, \
-                    'failed to recover before timeout expired'
+                if time.time() - start >= timeout:
+                    self.log('dumping pgs')
+                    out = self.raw_cluster_cmd('pg', 'dump')
+                    self.log(out)
+                    assert time.time() - start < timeout, \
+                        'failed to recover before timeout expired'
             cur_active_down = self.get_num_active_down()
             if cur_active_down != num_active_down:
                 start = time.time()
@@ -1711,8 +1723,12 @@ class CephManager:
         start = time.time()
         while not self.is_active():
             if timeout is not None:
-                assert time.time() - start < timeout, \
-                    'failed to become active before timeout expired'
+                if time.time() - start >= timeout:
+                    self.log('dumping pgs')
+                    out = self.raw_cluster_cmd('pg', 'dump')
+                    self.log(out)
+                    assert time.time() - start < timeout, \
+                        'failed to become active before timeout expired'
             time.sleep(3)
         self.log("active!")
 


### PR DESCRIPTION
We were doing this for one of the recovery timeouts but not all of them.

Signed-off-by: Sage Weil <sage@redhat.com>