### PR TITLE
tasks/cephfs: vstart & fuse improvements

### DIFF
--- a/tasks/cephfs/fuse_mount.py
+++ b/tasks/cephfs/fuse_mount.py
@@ -153,7 +153,8 @@ class FuseMount(CephFSMount):
         try:
             proc.wait()
         except CommandFailedError:
-            if "endpoint is not connected" in proc.stderr.getvalue():
+            if ("endpoint is not connected" in proc.stderr.getvalue()
+            or "Software caused connection abort" in proc.stderr.getvalue()):
                 # This happens is fuse is killed without unmount
                 log.warn("Found stale moutn point at {0}".format(self.mountpoint))
                 return True

--- a/tasks/cephfs/vstart_runner.py
+++ b/tasks/cephfs/vstart_runner.py
@@ -402,6 +402,10 @@ class LocalFuseMount(FuseMount):
         waited = 0
         post_mount_conns = list_connections()
         while len(post_mount_conns) <= len(pre_mount_conns):
+            if self.fuse_daemon.finished:
+                # Did mount fail?  Raise the CommandFailedError instead of
+                # hitting the "failed to populate /sys/" timeout
+                self.fuse_daemon.wait()
             time.sleep(1)
             waited += 1
             if waited > 30:


### PR DESCRIPTION
A couple of corner cases that would get tripped up sometimes
in a vstart_runner.py environment.

Signed-off-by: John Spray <john.spray@redhat.com>