### PR TITLE
rados/singleton-nomsgr/all/11429: no mds

### DIFF
--- a/suites/rados/singleton-nomsgr/all/11429.yaml
+++ b/suites/rados/singleton-nomsgr/all/11429.yaml
@@ -22,7 +22,6 @@ overrides:
     - failed to encode
 roles:
 - - mon.a
-  - mds.a
   - osd.0
   - osd.1
   - mon.b
@@ -93,7 +92,7 @@ tasks:
   - install.upgrade:
       mon.a:
         branch: hammer
-  - ceph.restart: [mon.a, mon.b, mon.c, osd.0, osd.1, osd.2, mds.a]
+  - ceph.restart: [mon.a, mon.b, mon.c, osd.0, osd.1, osd.2]
   - ceph_manager.wait_for_clean: null
   - ceph.restart: [osd.0, osd.1, osd.2]
   - ceph_manager.wait_for_clean: null
@@ -104,7 +103,7 @@ tasks:
 
   - install.upgrade:
       mon.a: null
-  - ceph.restart: [mon.a, mon.b, mon.c, osd.0, osd.1, osd.2, mds.a]
+  - ceph.restart: [mon.a, mon.b, mon.c, osd.0, osd.1, osd.2]
   - ceph_manager.wait_for_clean: null
   - ceph.restart: [osd.0, osd.1, osd.2]
   - exec:


### PR DESCRIPTION
The newer cephfs logic wants to use the 'status' command on the
daemon, but that doesn't exist on firefly.  Luckly we don't need
it for this test.

Signed-off-by: Sage Weil <sage@redhat.com>