### PR TITLE
tasks/cephfs: support old mdsmap command during setup

### DIFF
--- a/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
+++ b/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
@@ -6,9 +6,9 @@ tasks:
 - exec:
     client.0:
     - ceph osd pool create data_cache 4
-    - ceph osd tier add data data_cache
+    - ceph osd tier add cephfs_data data_cache
     - ceph osd tier cache-mode data_cache writeback
-    - ceph osd tier set-overlay data data_cache
+    - ceph osd tier set-overlay cephfs_data data_cache
     - ceph osd pool set data_cache hit_set_type bloom
     - ceph osd pool set data_cache hit_set_count 8
     - ceph osd pool set data_cache hit_set_period 3600


### PR DESCRIPTION
While Filesystem at large requires the new commands, for
use from the `ceph` task we must support old style commands,
as the ceph task is used to instantiate old clusters during
upgrade testing.

Fixes: #15124, #15049, #15106

Signed-off-by: John Spray <john.spray@redhat.com>