### PR TITLE
suites: remove unused mdss from RADOS tests

### DIFF
--- a/suites/rados/singleton-nomsgr/all/13234.yaml
+++ b/suites/rados/singleton-nomsgr/all/13234.yaml
@@ -22,7 +22,6 @@ overrides:
     - failed to encode
 roles:
 - - mon.a
-  - mds.a
   - osd.0
   - osd.1
   - mon.b

--- a/suites/rados/singleton-nomsgr/all/full-tiering.yaml
+++ b/suites/rados/singleton-nomsgr/all/full-tiering.yaml
@@ -1,6 +1,6 @@
 # verify #13098 fix
 roles:
-- [mon.a, mds.a, osd.0, osd.1, osd.2, client.0]
+- [mon.a, osd.0, osd.1, osd.2, client.0]
 overrides:
   ceph:
     log-whitelist:

--- a/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
+++ b/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
@@ -11,7 +11,6 @@ overrides:
     valgrind:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]
-      mds: [--tool=memcheck]
 roles:
 - [mon.0, osd.0, osd.1, client.0]
 tasks:

--- a/suites/rados/upgrade/hammer-x-singleton/0-cluster/start.yaml
+++ b/suites/rados/upgrade/hammer-x-singleton/0-cluster/start.yaml
@@ -7,7 +7,6 @@ roles:
 - - mon.a
   - mon.b
   - mon.c
-  - mds.a
   - osd.0
   - osd.1
   - osd.2


### PR DESCRIPTION
These daemons were apparently unused in tests that
created an MDS daemon but never use a fuse task
to access it.

Signed-off-by: John Spray <john.spray@redhat.com>