### PR TITLE
tasks/ceph.py: Remove *.pid at end of run

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -877,6 +877,7 @@ def cluster(ctx, config):
                     keyring_path,
                     '{tdir}/data'.format(tdir=testdir),
                     '{tdir}/monmap'.format(tdir=testdir),
+                    run.Raw('{tdir}/../*.pid'.format(tdir=testdir)),
                 ],
                 wait=False,
             ),


### PR DESCRIPTION
Fixes: #15162
Signed-off-by: Dan Mick <dan.mick@redhat.com>