### PR TITLE
upgrade: use infernalis instead of hammer for rbd tests

### DIFF
--- a/suites/upgrade/infernalis-x/stress-split/5-workload/rbd-cls.yaml
+++ b/suites/upgrade/infernalis-x/stress-split/5-workload/rbd-cls.yaml
@@ -3,7 +3,7 @@ meta:
    run basic cls tests for rbd
 tasks:
 - workunit:
-    branch: hammer
+    branch: infernalis
     clients:
       client.0:
         - cls/test_cls_rbd.sh

--- a/suites/upgrade/infernalis-x/stress-split/5-workload/rbd-import-export.yaml
+++ b/suites/upgrade/infernalis-x/stress-split/5-workload/rbd-import-export.yaml
@@ -3,7 +3,7 @@ meta:
    run basic import/export cli tests for rbd
 tasks:
 - workunit:
-    branch: hammer
+    branch: infernalis
     clients:
       client.0:
         - rbd/import_export.sh

--- a/suites/upgrade/infernalis-x/stress-split/7-workload/rbd_api.yaml
+++ b/suites/upgrade/infernalis-x/stress-split/7-workload/rbd_api.yaml
@@ -3,7 +3,7 @@ meta:
    librbd C and C++ api tests
 tasks:
 - workunit:
-     branch: hammer
+     branch: infernalis
      clients:
         client.0:
            - rbd/test_librbd.sh

--- a/suites/upgrade/infernalis-x/stress-split/9-workload/rbd-python.yaml
+++ b/suites/upgrade/infernalis-x/stress-split/9-workload/rbd-python.yaml
@@ -3,7 +3,7 @@ meta:
    librbd python api tests
 tasks:
 - workunit:
-    branch: hammer
+    branch: infernalis
     clients:
       client.0:
         - rbd/test_librbd_python.sh


### PR DESCRIPTION
There are only few differences at the moment but it may be confusing
later on if a bug is fixed in the infernalis workunits later on.

Signed-off-by: Loic Dachary <loic@dachary.org>