### PR TITLE
suites: run rados bench for max 180 seconds

### DIFF
--- a/suites/powercycle/osd/tasks/radosbench.yaml
+++ b/suites/powercycle/osd/tasks/radosbench.yaml
@@ -1,4 +1,23 @@
 tasks:
-- radosbench:
-    clients: [client.0]
-    time: 200
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180

--- a/suites/rados/thrash-erasure-code/workloads/ec-radosbench.yaml
+++ b/suites/rados/thrash-erasure-code/workloads/ec-radosbench.yaml
@@ -1,6 +1,17 @@
 tasks:
-- radosbench:
-    clients: [client.0]
-    time: 300
-    unique_pool: true
-    ec_pool: true
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 180
+      unique_pool: true
+      ec_pool: true
+  - radosbench:
+      clients: [client.0]
+      time: 180
+      unique_pool: true
+      ec_pool: true
+  - radosbench:
+      clients: [client.0]
+      time: 180
+      unique_pool: true
+      ec_pool: true

--- a/suites/rados/thrash/workloads/radosbench.yaml
+++ b/suites/rados/thrash/workloads/radosbench.yaml
@@ -6,6 +6,16 @@ overrides:
         debug objecter: 20
         debug rados: 20
 tasks:
-- radosbench:
-    clients: [client.0]
-    time: 200
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180

--- a/suites/rados/upgrade/hammer-x-singleton/7-workload/radosbench.yaml
+++ b/suites/rados/upgrade/hammer-x-singleton/7-workload/radosbench.yaml
@@ -1,5 +1,15 @@
 tasks:
-- radosbench:
-    clients: [client.0]
-    time: 900
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
 - print: "**** done radosbench 7-workload"

--- a/suites/smoke/basic/tasks/rados_bench.yaml
+++ b/suites/smoke/basic/tasks/rados_bench.yaml
@@ -18,7 +18,16 @@ tasks:
     chance_pgnum_grow: 2
     chance_pgpnum_fix: 1
     timeout: 1200
-- radosbench:
-    clients:
-    - client.0
-    time: 1800
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180

--- a/suites/upgrade/firefly-hammer-x/stress-split/07-workload/radosbench.yaml
+++ b/suites/upgrade/firefly-hammer-x/stress-split/07-workload/radosbench.yaml
@@ -1,5 +1,27 @@
 tasks:
-- radosbench:
-    clients: [client.0]
-    time: 1800
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
 - print: "**** done 07-workload/radosbench.yaml"

--- a/suites/upgrade/firefly-hammer-x/stress-split/19-workload/radosbench.yaml
+++ b/suites/upgrade/firefly-hammer-x/stress-split/19-workload/radosbench.yaml
@@ -1,5 +1,27 @@
 tasks:
-- radosbench:
-    clients: [client.0]
-    time: 1800
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
 - print: "**** done 19-workload/radosbench.yaml"

--- a/suites/upgrade/hammer-x/stress-split/7-workload/radosbench.yaml
+++ b/suites/upgrade/hammer-x/stress-split/7-workload/radosbench.yaml
@@ -2,5 +2,29 @@ tasks:
 - full_sequential:
   - radosbench:
       clients: [client.0]
-      time: 1800
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
 - print: "**** done radosbench 7-workload"

--- a/suites/upgrade/infernalis-x/stress-split/7-workload/radosbench.yaml
+++ b/suites/upgrade/infernalis-x/stress-split/7-workload/radosbench.yaml
@@ -6,5 +6,29 @@ tasks:
 - full_sequential:
   - radosbench:
       clients: [client.0]
-      time: 1800
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      time: 180
 - print: "**** done radosbench 7-workload"


### PR DESCRIPTION
If we want a longer runtime than that, run it several times in
sequence.

This limits the amount of disk space we'll consume.

Signed-off-by: Sage Weil <sage@redhat.com>