### PR TITLE
Added blogbench.yaml to parallel before and after -x upgrade steps

### DIFF
--- a/suites/upgrade/hammer-x/parallel/2-workload/blogbench.yaml
+++ b/suites/upgrade/hammer-x/parallel/2-workload/blogbench.yaml
@@ -3,11 +3,12 @@ meta:
    run a cephfs stress test
    mount ceph-fuse on client.2 before running workunit
 workload:
-  sequential:
-  - ceph-fuse:
-  - print: "**** done ceph-fuse 2-workload"
-  - workunit:
-      clients:
-         client.2:
-          - suites/blogbench.sh
-  - print: "**** done suites/blogbench.sh 2-workload"
+  full_sequential:
+  - sequential:
+    - ceph-fuse:
+    - print: "**** done ceph-fuse 2-workload"
+    - workunit:
+        clients:
+           client.2:
+            - suites/blogbench.sh
+    - print: "**** done suites/blogbench.sh 2-workload"

--- a/suites/upgrade/infernalis-x/parallel/2-workload/blogbench.yaml
+++ b/suites/upgrade/infernalis-x/parallel/2-workload/blogbench.yaml
@@ -3,11 +3,12 @@ meta:
    run a cephfs stress test
    mount ceph-fuse on client.2 before running workunit
 workload:
-  sequential:
-  - ceph-fuse:
-  - print: "**** done ceph-fuse 2-workload"
-  - workunit:
-      clients:
-         client.2:
-          - suites/blogbench.sh
-  - print: "**** done suites/blogbench.sh 2-workload"
+  full_sequential:
+  - sequential:
+    - ceph-fuse:
+    - print: "**** done ceph-fuse 2-workload"
+    - workunit:
+        clients:
+           client.2:
+            - suites/blogbench.sh
+    - print: "**** done suites/blogbench.sh 2-workload"

--- a/suites/upgrade/infernalis-x/parallel/2-workload/ec-rados-default.yaml
+++ b/suites/upgrade/infernalis-x/parallel/2-workload/ec-rados-default.yaml
@@ -2,8 +2,8 @@ meta:
 - desc: |
    run run randomized correctness test for rados operations
    on an erasure-coded pool
-tasks:
-- full_sequential:
+workload:
+  full_sequential:
   - rados:
       clients: [client.0]
       ops: 4000


### PR DESCRIPTION
Fixes #15093

Note: sequential and full_sequential (dictionary) can't be both under parallel stanza

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>