### PR TITLE
[DNM] s3readwrite: set debug level to 2 for boto

### DIFF
--- a/suites/rados/thrash/workloads/rgw_snaps.yaml
+++ b/suites/rados/thrash/workloads/rgw_snaps.yaml
@@ -29,3 +29,4 @@ overrides:
     conf:
       client:
         debug rgw: 20
+        debug ms: 5

--- a/suites/rados/thrash/workloads/rgw_snaps.yaml
+++ b/suites/rados/thrash/workloads/rgw_snaps.yaml
@@ -14,6 +14,7 @@ tasks:
 - s3readwrite:
     client.0:
       rgw_server: client.0
+      force-branch: wip-boto-debug
       readwrite:
         bucket: rwtest
         readers: 10

--- a/suites/rados/thrash/workloads/rgw_snaps.yaml
+++ b/suites/rados/thrash/workloads/rgw_snaps.yaml
@@ -24,3 +24,8 @@ tasks:
           num: 10
           size: 2000
           stddev: 500
+overrides:
+  ceph:
+    conf:
+      client:
+        debug rgw: 20

--- a/suites/rgw/multifs/tasks/rgw_readwrite.yaml
+++ b/suites/rgw/multifs/tasks/rgw_readwrite.yaml
@@ -20,3 +20,4 @@ overrides:
     conf:
       client:
         debug rgw: 20
+        debug ms: 5

--- a/suites/rgw/multifs/tasks/rgw_readwrite.yaml
+++ b/suites/rgw/multifs/tasks/rgw_readwrite.yaml
@@ -5,6 +5,7 @@ tasks:
 - s3readwrite:
     client.0:
       rgw_server: client.0
+      force-branch: wip-boto-debug
       readwrite:
         bucket: rwtest
         readers: 10

--- a/suites/rgw/multifs/tasks/rgw_readwrite.yaml
+++ b/suites/rgw/multifs/tasks/rgw_readwrite.yaml
@@ -15,3 +15,8 @@ tasks:
           num: 10
           size: 2000
           stddev: 500 
+overrides:
+  ceph:
+    conf:
+      client:
+        debug rgw: 20

--- a/tasks/s3readwrite.py
+++ b/tasks/s3readwrite.py
@@ -77,6 +77,7 @@ def _config_user(s3tests_conf, section, user):
     s3tests_conf[section].setdefault('display_name', 'Mr. {user}'.format(user=user))
     s3tests_conf[section].setdefault('access_key', ''.join(random.choice(string.uppercase) for i in xrange(20)))
     s3tests_conf[section].setdefault('secret_key', base64.b64encode(os.urandom(40)))
+    s3tests_conf[section].setdefault('debug', 2)
 
 @contextlib.contextmanager
 def create_users(ctx, config):


### PR DESCRIPTION
This is for debugging the dns issue, let us crank up logging with boto
and see if we can find the cause of the issue

Signed-off-by: Abhishek Lekshmanan abhishek@suse.com
