### PR TITLE
morepggrow: enable filestore and journal soft backoffs

### DIFF
--- a/suites/rados/thrash/thrashers/morepggrow.yaml
+++ b/suites/rados/thrash/thrashers/morepggrow.yaml
@@ -6,6 +6,10 @@ tasks:
         osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        journal throttle high multiple: 2
+        journal throttle max multiple: 10
+        filestore queue throttle high multiple: 2
+        filestore queue throttle max multiple: 10
     log-whitelist:
     - wrongly marked me down
     - objects unfound and apparently lost


### PR DESCRIPTION
Signed-off-by: Samuel Just <sjust@redhat.com>