### PR TITLE
cephfs: update tests to enable multimds when needed

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -292,6 +292,13 @@ def cephfs_setup(ctx, config):
             'adjust-ulimits',
             'ceph-coverage',
             coverage_dir,
+            'ceph', 'mds', 'set', 'allow_multimds', 'true',
+            '--yes-i-really-mean-it'])
+        mon_remote.run(args=[
+            'sudo',
+            'adjust-ulimits',
+            'ceph-coverage',
+            coverage_dir,
             'ceph',
             'mds', 'set_max_mds', str(num_active)])
 

--- a/tasks/cephfs/test_data_scan.py
+++ b/tasks/cephfs/test_data_scan.py
@@ -426,6 +426,9 @@ class TestDataScan(CephFSTestCase):
         That when injecting a dentry into a fragmented directory, we put it in the right fragment.
         """
 
+        self.fs.mon_manager.raw_cluster_cmd("mds", "set", "allow_dirfrags", "true",
+                                            "--yes-i-really-mean-it")
+
         file_count = 100
         file_names = ["%s" % n for n in range(0, file_count)]
 

--- a/tasks/cephfs/test_failover.py
+++ b/tasks/cephfs/test_failover.py
@@ -160,7 +160,11 @@ class TestMultiFilesystems(CephFSTestCase):
     def setUp(self):
         super(TestMultiFilesystems, self).setUp()
         self.fs.mon_manager.raw_cluster_cmd("fs", "flag", "set",
-                                            "enable_multiple", "true")
+                                            "enable_multiple", "true",
+                                            "--yes-i-really-mean-it")
+        self.fs.mon_manager.raw_cluster_cmd("mds", "set",
+                                            "allow_multimds", "true",
+                                            "--yes-i-really-mean-it")
 
     def _setup_two(self):
         fs_a = self.mds_cluster.get_filesystem("alpha")

--- a/tasks/cephfs/test_failover.py
+++ b/tasks/cephfs/test_failover.py
@@ -162,9 +162,6 @@ class TestMultiFilesystems(CephFSTestCase):
         self.fs.mon_manager.raw_cluster_cmd("fs", "flag", "set",
                                             "enable_multiple", "true",
                                             "--yes-i-really-mean-it")
-        self.fs.mon_manager.raw_cluster_cmd("mds", "set",
-                                            "allow_multimds", "true",
-                                            "--yes-i-really-mean-it")
 
     def _setup_two(self):
         fs_a = self.mds_cluster.get_filesystem("alpha")
@@ -265,6 +262,13 @@ class TestMultiFilesystems(CephFSTestCase):
     def test_grow_shrink(self):
         # Usual setup...
         fs_a, fs_b = self._setup_two()
+        fs_a.mon_manager.raw_cluster_cmd("fs", "set", fs_a.name,
+                                         "allow_multimds", "true",
+                                         "--yes-i-really-mean-it")
+
+        fs_b.mon_manager.raw_cluster_cmd("fs", "set", fs_b.name,
+                                         "allow_multimds", "true",
+                                         "--yes-i-really-mean-it")
 
         # Increase max_mds on fs_b, see a standby take up the role
         fs_b.mon_manager.raw_cluster_cmd('fs', 'set', fs_b.name, 'max_mds', "2")
@@ -435,8 +439,16 @@ class TestMultiFilesystems(CephFSTestCase):
         # Create two filesystems which should have two ranks each
         fs_a = self.mds_cluster.get_filesystem("alpha")
         fs_a.create()
+        fs_a.mon_manager.raw_cluster_cmd("fs", "set", fs_a.name,
+                                         "allow_multimds", "true",
+                                         "--yes-i-really-mean-it")
+
         fs_b = self.mds_cluster.get_filesystem("bravo")
         fs_b.create()
+        fs_b.mon_manager.raw_cluster_cmd("fs", "set", fs_b.name,
+                                         "allow_multimds", "true",
+                                         "--yes-i-really-mean-it")
+
         fs_a.mon_manager.raw_cluster_cmd('fs', 'set', fs_a.name,
                                          'max_mds', "2")
         fs_b.mon_manager.raw_cluster_cmd('fs', 'set', fs_b.name,

--- a/tasks/cephfs/test_journal_repair.py
+++ b/tasks/cephfs/test_journal_repair.py
@@ -160,6 +160,8 @@ class TestJournalRepair(CephFSTestCase):
         """
 
         # Set max_mds to 2
+        self.fs.mon_manager.raw_cluster_cmd_result('mds', 'set', "allow_multimds",
+                                                   "true", "--yes-i-really-mean-it")
         self.fs.mon_manager.raw_cluster_cmd_result('mds', 'set', "max_mds", "2")
 
         # See that we have two active MDSs

--- a/tasks/cephfs/test_sessionmap.py
+++ b/tasks/cephfs/test_sessionmap.py
@@ -96,6 +96,8 @@ class TestSessionMap(CephFSTestCase):
         self.fs.wait_for_daemons()
 
         # I would like two MDSs, so that I can do an export dir later
+        self.fs.mon_manager.raw_cluster_cmd_result('mds', 'set', "allow_multimds",
+                                                   "true", "--yes-i-really-mean-it")
         self.fs.mon_manager.raw_cluster_cmd_result('mds', 'set', "max_mds", "2")
         self.fs.wait_for_daemons()
 

--- a/tasks/cephfs/test_strays.py
+++ b/tasks/cephfs/test_strays.py
@@ -414,6 +414,8 @@ class TestStrays(CephFSTestCase):
         """
 
         # Set up two MDSs
+        self.fs.mon_manager.raw_cluster_cmd_result('mds', 'set', "allow_multimds",
+                                                   "true", "--yes-i-really-mean-it")
         self.fs.mon_manager.raw_cluster_cmd_result('mds', 'set', "max_mds", "2")
 
         # See that we have two active MDSs


### PR DESCRIPTION
We've disabled certain FS behaviors by default and need to turn them on when testing.