### PR TITLE
tasks/cephfs: test health messages from readonly stat

### DIFF
--- a/tasks/cephfs/cephfs_test_case.py
+++ b/tasks/cephfs/cephfs_test_case.py
@@ -399,3 +399,13 @@ class CephFSTestCase(unittest.TestCase):
                 raise RuntimeError("Unexpected health messages: {0}".format(summary_strings))
 
         self.wait_until_true(seen_health_warning, timeout)
+
+    def wait_for_health_clear(self, timeout):
+        """
+        Wait until `ceph health` returns no messages
+        """
+        def is_clear():
+            health = self.fs.mon_manager.get_mon_health()
+            return len(health['summary']) == 0
+
+        self.wait_until_true(is_clear, timeout)

--- a/tasks/cephfs/test_auto_repair.py
+++ b/tasks/cephfs/test_auto_repair.py
@@ -80,6 +80,11 @@ class TestMDSAutoRepair(CephFSTestCase):
         # background writer also should fail
         self.assertTrue(writer.finished)
 
+        # The MDS should report its readonly health state to the mon
+        self.wait_for_health("MDS in read-only mode", timeout=30)
+
         # restart mds to make it writable
         self.fs.mds_fail_restart()
         self.fs.wait_for_daemons()
+
+        self.wait_for_health_clear(timeout=30)


### PR DESCRIPTION
Signed-off-by: John Spray <john.spray@redhat.com>