### PR TITLE
rgw: use civetweb if no frontend was configured

### DIFF
--- a/tasks/rgw.py
+++ b/tasks/rgw.py
@@ -871,7 +871,7 @@ def task(ctx, config):
         ctx.rgw.cache_pools = bool(config['cache-pools'])
         del config['cache-pools']
 
-    ctx.rgw.frontend = 'apache'
+    ctx.rgw.frontend = 'civetweb'
     if 'frontend' in config:
         ctx.rgw.frontend = config['frontend']
         del config['frontend']


### PR DESCRIPTION
Signed-off-by: Orit Wasserman <owasserm@redhat.com>