### PR TITLE
tasks/cephfs: test volume client eviction

### DIFF
--- a/suites/fs/recovery/clusters/4-remote-clients.yaml
+++ b/suites/fs/recovery/clusters/4-remote-clients.yaml
@@ -1,5 +1,5 @@
 roles:
-- [mon.a, osd.0, mds.a, mds.b, client.1, client.2]
+- [mon.a, osd.0, mds.a, mds.b, client.1, client.2, client.3]
 - [client.0, osd.1, osd.2]
 log-rotate:
   ceph-mds: 10G

--- a/suites/fs/recovery/mounts/ceph-fuse.yaml
+++ b/suites/fs/recovery/mounts/ceph-fuse.yaml
@@ -8,3 +8,5 @@ tasks:
         mounted: false
     client.2:
         mounted: false
+    client.3:
+        mounted: false

--- a/tasks/cephfs/mount.py
+++ b/tasks/cephfs/mount.py
@@ -23,6 +23,7 @@ class CephFSMount(object):
         self.test_dir = test_dir
         self.client_id = client_id
         self.client_remote = client_remote
+        self.mountpoint_dir_name = 'mnt.{id}'.format(id=self.client_id)
 
         self.test_files = ['a', 'b', 'c']
 
@@ -30,7 +31,8 @@ class CephFSMount(object):
 
     @property
     def mountpoint(self):
-        return os.path.join(self.test_dir, 'mnt.{id}'.format(id=self.client_id))
+        return os.path.join(
+            self.test_dir, '{dir_name}'.format(dir_name=self.mountpoint_dir_name))
 
     def is_mounted(self):
         raise NotImplementedError()

--- a/tasks/cephfs/vstart_runner.py
+++ b/tasks/cephfs/vstart_runner.py
@@ -678,7 +678,7 @@ def exec_test():
     test_dir = tempfile.mkdtemp()
 
     # Create as many of these as the biggest test requires
-    clients = ["0", "1", "2"]
+    clients = ["0", "1", "2", "3"]
 
     remote = LocalRemote()
 


### PR DESCRIPTION
Test whether the CephFSVolumeClient can evict a client based on its
auth ID and the volume path it has mounted.

Fixes: http://tracker.ceph.com/issues/15045

Signed-off-by: Ramana Raja <rraja@redhat.com>