### PR TITLE
rgw/verify: use rgw_compression_type = "random"

### DIFF
--- a/suites/rgw/verify/overrides.yaml
+++ b/suites/rgw/verify/overrides.yaml
@@ -3,5 +3,6 @@ overrides:
     conf:
       client:
         debug rgw: 20
+        rgw compression type: random
   rgw:
     frontend: civetweb

--- a/tasks/rgw.py
+++ b/tasks/rgw.py
@@ -494,11 +494,13 @@ def extract_zone_info(ctx, client, client_config):
     index_pool = '.' + region + '.' + zone + '.' + 'index_pool'
     data_pool = '.' + region + '.' + zone + '.' + 'data_pool'
     data_extra_pool = '.' + region + '.' + zone + '.' + 'data_extra_pool'
+    compression_type = ceph_config.get('rgw compression type', '')
 
     zone_info['placement_pools'] = [{'key': 'default_placement',
                                      'val': {'index_pool': index_pool,
                                              'data_pool': data_pool,
-                                             'data_extra_pool': data_extra_pool}
+                                             'data_extra_pool': data_extra_pool,
+                                             'compression': compression_type}
                                      }]
 
     # these keys are meant for the zones argument in the region info.  We


### PR DESCRIPTION
~~This is my naive attempt to add `rgw_compression_type={none, snappy, zlib}` to the test matrix of the rgw suite to validate https://github.com/ceph/ceph/pull/7715. I would eventually like to narrow down which parts of the rgw suite test with compression.. maybe just running s3tests against each type is good enough.~~

This uses the new compressor plugin factory's support for the compression type "random" (see https://github.com/ceph/ceph/pull/11901) to get test coverage of all supported compression types without expanding the test matrix of the rgw suite.