### PR TITLE
rados: vary mon kv backend

### DIFF
--- a/mon_kv_backend/leveldb.yaml
+++ b/mon_kv_backend/leveldb.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      mon:
+        mon keyvaluedb: leveldb

--- a/mon_kv_backend/rocksdb.yaml
+++ b/mon_kv_backend/rocksdb.yaml
@@ -1,0 +1,7 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: '*'
+      mon:
+        mon keyvaluedb: rocksdb

--- a/suites/rados/basic/mon_kv_backend
+++ b/suites/rados/basic/mon_kv_backend
@@ -1,0 +1,1 @@
+../../../mon_kv_backend

--- a/suites/rados/monthrash/mon_kv_backend
+++ b/suites/rados/monthrash/mon_kv_backend
@@ -1,0 +1,1 @@
+../../../mon_kv_backend

--- a/suites/rados/multimon/mon_kv_backend
+++ b/suites/rados/multimon/mon_kv_backend
@@ -1,0 +1,1 @@
+../../../mon_kv_backend

--- a/suites/rados/thrash-erasure-code-big/leveldb.yaml
+++ b/suites/rados/thrash-erasure-code-big/leveldb.yaml
@@ -1,0 +1,1 @@
+../../../mon_kv_backend/leveldb.yaml

--- a/suites/rados/thrash-erasure-code-isa/leveldb.yaml
+++ b/suites/rados/thrash-erasure-code-isa/leveldb.yaml
@@ -1,0 +1,1 @@
+../../../mon_kv_backend/leveldb.yaml

--- a/suites/rados/thrash-erasure-code-shec/leveldb.yaml
+++ b/suites/rados/thrash-erasure-code-shec/leveldb.yaml
@@ -1,0 +1,1 @@
+../../../mon_kv_backend/leveldb.yaml

--- a/suites/rados/thrash-erasure-code/leveldb.yaml
+++ b/suites/rados/thrash-erasure-code/leveldb.yaml
@@ -1,0 +1,1 @@
+../../../mon_kv_backend/leveldb.yaml

--- a/suites/rados/thrash/rocksdb.yaml
+++ b/suites/rados/thrash/rocksdb.yaml
@@ -1,0 +1,1 @@
+../../../mon_kv_backend/rocksdb.yaml

--- a/suites/rados/verify/mon_kv_backend
+++ b/suites/rados/verify/mon_kv_backend
@@ -1,0 +1,1 @@
+../../../mon_kv_backend


### PR DESCRIPTION
Use just rocksdb for thrash to avoid blowing up the matrix.  Leave
leveldb for the ec thrash suites.

Signed-off-by: Sage Weil <sage@redhat.com>