### PR TITLE
Fix infinite wait during monitor quorum check

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -1211,22 +1211,23 @@ def wait_for_mon_quorum(ctx, config):
         cluster_name = 'ceph'
     firstmon = teuthology.get_first_mon(ctx, config, cluster_name)
     (remote,) = ctx.cluster.only(firstmon).remotes.keys()
-    while True:
-        r = remote.run(
-            args=[
-                'sudo',
-                'ceph',
-                'quorum_status',
-            ],
-            stdout=StringIO(),
-            logger=log.getChild('quorum_status'),
-        )
-        j = json.loads(r.stdout.getvalue())
-        q = j.get('quorum_names', [])
-        log.debug('Quorum: %s', q)
-        if sorted(q) == sorted(mons):
-            break
-        time.sleep(1)
+    with contextutil.safe_while(sleep=10, tries=60,
+                                action='wait for monitor quorum') as proceed:
+        while proceed():
+            r = remote.run(
+                args=[
+                    'sudo',
+                    'ceph',
+                    'quorum_status',
+                ],
+                stdout=StringIO(),
+                logger=log.getChild('quorum_status'),
+            )
+            j = json.loads(r.stdout.getvalue())
+            q = j.get('quorum_names', [])
+            log.debug('Quorum: %s', q)
+            if sorted(q) == sorted(mons):
+                break
 
 
 def created_pool(ctx, config):


### PR DESCRIPTION
The current loop can cause the logs to run into huge file and loop forever in case of dead monitors, This change will cause it exit after 10minutes if they dont reach quorum.

Signed-off-by: Vasu Kulkarni vasu@redhat.com
