### PR TITLE
suites/rados: test osd_discard_disconnected_ops

### DIFF
--- a/suites/rados/thrash/workloads/readwrite.yaml
+++ b/suites/rados/thrash/workloads/readwrite.yaml
@@ -1,6 +1,9 @@
 overrides:
   ceph:
     crush_tunables: optimal
+    conf:
+      osd:
+        osd_discard_disconnected_ops: false
 tasks:
 - rados:
     clients: [client.0]


### PR DESCRIPTION
In ceph.git i propose "PG: no need to judge op_is_discardable after op has been dequeued" https://github.com/ceph/ceph/pull/8717

Here to test the parameter osd_discard_disconnected_ops