### PR TITLE
rados: test jewel instead of legacy tunables

### DIFF
--- a/suites/rados/thrash/workloads/small-objects.yaml
+++ b/suites/rados/thrash/workloads/small-objects.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    crush_tunables: legacy
+    crush_tunables: jewel
 tasks:
 - rados:
     clients: [client.0]


### PR DESCRIPTION
Legacy tunables semi-frequently turn up crush mappings that only
return 1 instead of 2 results.  Switch to covering jewel tunables
explicitly instead.

Signed-off-by: Sage Weil <sage@redhat.com>