### PR TITLE
tasks/cephfs: fix ps usage to not truncate cmds

### DIFF
--- a/tasks/cephfs/test_sessionmap.py
+++ b/tasks/cephfs/test_sessionmap.py
@@ -30,7 +30,7 @@ class TestSessionMap(CephFSTestCase):
         remote = self.fs.mds_daemons[mds_id].remote
 
         ps_txt = remote.run(
-            args=["ps", "axo", "cmd,nlwp"],
+            args=["ps", "-ww", "axo", "nlwp,cmd"],
             stdout=StringIO()
         ).stdout.getvalue().strip()
         lines = ps_txt.split("\n")[1:]
@@ -39,7 +39,7 @@ class TestSessionMap(CephFSTestCase):
             if line.find("ceph-mds") != -1:
                 if line.find("-i {0}".format(mds_id)) != -1:
                     log.info("Found ps line for daemon: {0}".format(line))
-                    return int(line.split()[-1])
+                    return int(line.split()[0])
 
         raise RuntimeError("No process found in ps output for MDS {0}: {1}".format(
             mds_id, ps_txt


### PR DESCRIPTION
Now that daemon commandlines include "--cluster" they
easily overflow ps's default behaviour.

Fixes: http://tracker.ceph.com/issues/15857
Signed-off-by: John Spray <john.spray@redhat.com>