### PR TITLE
add user-data for openSUSE 42.1

### DIFF
--- a/tasks/buildpackages/opensuse-42.1-user-data.txt
+++ b/tasks/buildpackages/opensuse-42.1-user-data.txt
@@ -1,0 +1,13 @@
+#cloud-config
+bootcmd:
+ - echo nameserver 8.8.8.8 | tee -a /etc/resolv.conf # last resort, in case the DHCP server does not provide a resolver
+manage_etc_hosts: true
+preserve_hostname: true
+users:
+  - name: ubuntu
+    gecos: User
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    groups: users
+runcmd:
+ - ( MYHOME=/home/ubuntu ; mkdir $MYHOME/.ssh ; chmod 700 $MYHOME/.ssh ; cp /root/.ssh/authorized_keys $MYHOME/.ssh ; chown -R ubuntu.users $MYHOME/.ssh )
+final_message: "READYTORUN"


### PR DESCRIPTION
This should be merged after https://github.com/ceph/teuthology/pull/858

When I can run "teuthology-openstack --suite buildpackages/any --filter suse_42" with this patch, it creates the buildpackages VM from the openSUSE Leap 42.1 image. Then it watches for READYTORUN in /var/lib/cloud-init-output.log (which succeeds) and after that it successfully runs a command before failing for a reason unrelated to this patch (i.e., because that command is not supported in openSUSE).

After merge, this should be cherry-picked to jewel, hammer, and firefly.
