### PR TITLE
(jewel) backport cephfs fixes for test broken by multi-cluster support

### DIFF
--- a/tasks/cephfs/test_sessionmap.py
+++ b/tasks/cephfs/test_sessionmap.py
@@ -30,7 +30,7 @@ class TestSessionMap(CephFSTestCase):
         remote = self.fs.mds_daemons[mds_id].remote
 
         ps_txt = remote.run(
-            args=["ps", "axo", "cmd,nlwp"],
+            args=["ps", "-ww", "axo", "nlwp,cmd"],
             stdout=StringIO()
         ).stdout.getvalue().strip()
         lines = ps_txt.split("\n")[1:]
@@ -39,7 +39,7 @@ class TestSessionMap(CephFSTestCase):
             if line.find("ceph-mds") != -1:
                 if line.find("-i {0}".format(mds_id)) != -1:
                     log.info("Found ps line for daemon: {0}".format(line))
-                    return int(line.split()[-1])
+                    return int(line.split()[0])
 
         raise RuntimeError("No process found in ps output for MDS {0}: {1}".format(
             mds_id, ps_txt

--- a/tasks/cephfs/test_sessionmap.py
+++ b/tasks/cephfs/test_sessionmap.py
@@ -36,7 +36,7 @@ class TestSessionMap(CephFSTestCase):
         lines = ps_txt.split("\n")[1:]
 
         for line in lines:
-            if line.find("ceph-mds") != -1:
+            if "ceph-mds" in line and not "daemon-helper" in line:
                 if line.find("-i {0}".format(mds_id)) != -1:
                     log.info("Found ps line for daemon: {0}".format(line))
                     return int(line.split()[0])

--- a/tasks/cephfs/test_sessionmap.py
+++ b/tasks/cephfs/test_sessionmap.py
@@ -74,6 +74,7 @@ class TestSessionMap(CephFSTestCase):
 
         initial_thread_count = self._get_thread_count(mds_id)
         self.mount_a.mount()
+        self.mount_a.wait_until_mounted()
         self.assertGreater(self._get_thread_count(mds_id), initial_thread_count)
         self.mount_a.umount_wait()
         final_thread_count = self._get_thread_count(mds_id)


### PR DESCRIPTION
Fixes test_mount_conn_close failure http://pulpito.ceph.com/teuthology-2016-05-22_02:10:01-fs-jewel---basic-smithi/207265/