### PR TITLE
rgw: split osd's in 2 nodes

### DIFF
--- a/suites/rgw/singleton/all/radosgw-admin-data-sync.yaml
+++ b/suites/rgw/singleton/all/radosgw-admin-data-sync.yaml
@@ -1,5 +1,6 @@
 roles:
-- [mon.a, osd.0, osd.1, osd.2, osd.3, client.0, client.1]
+- [mon.a, osd.0, client.0]
+- [osd.1, osd.2, osd.3, client.1]
 tasks:
 - install:
 - ceph:

--- a/suites/rgw/singleton/all/radosgw-admin.yaml
+++ b/suites/rgw/singleton/all/radosgw-admin.yaml
@@ -1,5 +1,6 @@
 roles:
-- [mon.a, osd.0, client.0, osd.1, osd.2, osd.3]
+- [mon.a, osd.0]
+- [client.0, osd.1, osd.2, osd.3]
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
http://tracker.ceph.com/issues/15612
Not all test machines(mira, vps) have 4 osd's and without this
change it will fail on nodes with < 4 osds, since one of the
osd will be on ext4 and it will hit long filename issue

Signed-off-by: Vasu Kulkarni vasu@redhat.com
