### PR TITLE
tasks: fix non-existent sleep function

### DIFF
--- a/tasks/object_source_down.py
+++ b/tasks/object_source_down.py
@@ -3,6 +3,7 @@ Test Object locations going down
 """
 import logging
 import ceph_manager
+import time
 from teuthology import misc as teuthology
 from util.rados import rados
 
@@ -26,7 +27,7 @@ def task(ctx, config):
         )
 
     while len(manager.get_osd_status()['up']) < 3:
-        manager.sleep(10)
+        time.sleep(10)
     manager.wait_for_clean()
 
     # something that is always there

--- a/tasks/osd_backfill.py
+++ b/tasks/osd_backfill.py
@@ -51,7 +51,7 @@ def task(ctx, config):
         )
 
     while len(manager.get_osd_status()['up']) < 3:
-        manager.sleep(10)
+        time.sleep(10)
     manager.raw_cluster_cmd('tell', 'osd.0', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.1', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.2', 'flush_pg_stats')

--- a/tasks/osd_recovery.py
+++ b/tasks/osd_recovery.py
@@ -51,7 +51,7 @@ def task(ctx, config):
         )
 
     while len(manager.get_osd_status()['up']) < 3:
-        manager.sleep(10)
+        time.sleep(10)
     manager.raw_cluster_cmd('tell', 'osd.0', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.1', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.2', 'flush_pg_stats')

--- a/tasks/peer.py
+++ b/tasks/peer.py
@@ -3,6 +3,7 @@ Peer test (Single test, not much configurable here)
 """
 import logging
 import json
+import time
 
 import ceph_manager
 from teuthology import misc as teuthology
@@ -28,7 +29,7 @@ def task(ctx, config):
         )
 
     while len(manager.get_osd_status()['up']) < 3:
-        manager.sleep(10)
+        time.sleep(10)
     manager.raw_cluster_cmd('tell', 'osd.0', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.1', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.2', 'flush_pg_stats')

--- a/tasks/recovery_bench.py
+++ b/tasks/recovery_bench.py
@@ -58,7 +58,7 @@ def task(ctx, config):
 
     num_osds = teuthology.num_instances_of_type(ctx.cluster, 'osd')
     while len(manager.get_osd_status()['up']) < num_osds:
-        manager.sleep(10)
+        time.sleep(10)
 
     bench_proc = RecoveryBencher(
         manager,

--- a/tasks/rep_lost_unfound_delete.py
+++ b/tasks/rep_lost_unfound_delete.py
@@ -31,7 +31,7 @@ def task(ctx, config):
         )
 
     while len(manager.get_osd_status()['up']) < 3:
-        manager.sleep(10)
+        time.sleep(10)
     manager.raw_cluster_cmd('tell', 'osd.0', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.1', 'flush_pg_stats')
     manager.raw_cluster_cmd('tell', 'osd.2', 'flush_pg_stats')

--- a/tasks/scrub.py
+++ b/tasks/scrub.py
@@ -49,7 +49,7 @@ def task(ctx, config):
 
     num_osds = teuthology.num_instances_of_type(ctx.cluster, 'osd')
     while len(manager.get_osd_status()['up']) < num_osds:
-        manager.sleep(10)
+        time.sleep(10)
 
     scrub_proc = Scrubber(
         manager,


### PR DESCRIPTION
CephManager has no sleep function. Use time.sleep() instead.

Ran into this while testing a branch. Apparently it doesn't happen
much since this hasn't changed in years, but the error was copied
into several tasks.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>