### PR TITLE
vstart_runner: only kill/look at user's processes

### DIFF
--- a/tasks/cephfs/vstart_runner.py
+++ b/tasks/cephfs/vstart_runner.py
@@ -257,14 +257,14 @@ class LocalDaemon(object):
         Return PID as an integer or None if not found
         """
         ps_txt = self.controller.run(
-            args=["ps", "aux"]
+            args=["ps", "-u"+str(os.getuid())]
         ).stdout.getvalue().strip()
         lines = ps_txt.split("\n")[1:]
 
         for line in lines:
             if line.find("ceph-{0} -i {1}".format(self.daemon_type, self.daemon_id)) != -1:
                 log.info("Found ps line for daemon: {0}".format(line))
-                return int(line.split()[1])
+                return int(line.split()[0])
 
         return None
 
@@ -684,13 +684,13 @@ def exec_test():
 
     # Tolerate no MDSs or clients running at start
     ps_txt = remote.run(
-        args=["ps", "aux"]
+        args=["ps", "-u"+str(os.getuid())]
     ).stdout.getvalue().strip()
     lines = ps_txt.split("\n")[1:]
 
     for line in lines:
         if 'ceph-fuse' in line or 'ceph-mds' in line:
-            pid = int(line.split()[1])
+            pid = int(line.split()[0])
             log.warn("Killing stray process {0}".format(line))
             os.kill(pid, signal.SIGKILL)
 


### PR DESCRIPTION
This prevents vstart_runner.py from trying to kill other user's ceph-mds/ceph-fuse instances.