### PR TITLE
vstart_runner: move info message for loaded mods

### DIFF
--- a/tasks/cephfs/vstart_runner.py
+++ b/tasks/cephfs/vstart_runner.py
@@ -828,8 +828,8 @@ def exec_test():
         module_suites = []
         for mod_name in modules:
             # Test names like cephfs.test_auto_repair
-            log.info("Loaded: {0}".format(list(module_suites)))
             module_suites.append(decorating_loader.loadTestsFromName(mod_name))
+        log.info("Loaded: {0}".format(list(module_suites)))
         overall_suite = suite.TestSuite(module_suites)
     else:
         log.info("Excuting all tests")


### PR DESCRIPTION
The message was printing loaded modules before loading each module.