### PR TITLE
tasks/cephfs: fix vstart runner _get_pid

### DIFF
--- a/tasks/cephfs/vstart_runner.py
+++ b/tasks/cephfs/vstart_runner.py
@@ -257,14 +257,14 @@ class LocalDaemon(object):
         Return PID as an integer or None if not found
         """
         ps_txt = self.controller.run(
-            args=["ps", "-u"+str(os.getuid())]
+            args=["ps", "-xu"+str(os.getuid())]
         ).stdout.getvalue().strip()
         lines = ps_txt.split("\n")[1:]
 
         for line in lines:
             if line.find("ceph-{0} -i {1}".format(self.daemon_type, self.daemon_id)) != -1:
                 log.info("Found ps line for daemon: {0}".format(line))
-                return int(line.split()[0])
+                return int(line.split()[1])
 
         return None
 


### PR DESCRIPTION
Dropping the 'x' caused the ps lines not to include
the "-i <myid>" part of the command line that we use
to find named daemons' pids.

Signed-off-by: John Spray <john.spray@redhat.com>