### PR TITLE
tasks/ceph-deploy: Run on multiple Python versions (2, 3)

### DIFF
--- a/suites/ceph-deploy/basic/python_versions/python_2.yaml
+++ b/suites/ceph-deploy/basic/python_versions/python_2.yaml
@@ -1,0 +1,3 @@
+overrides:
+  ceph-deploy:
+    python_version: "2"

--- a/suites/ceph-deploy/basic/python_versions/python_3.yaml
+++ b/suites/ceph-deploy/basic/python_versions/python_3.yaml
@@ -1,0 +1,3 @@
+overrides:
+  ceph-deploy:
+    python_version: "3"

--- a/tasks/ceph_deploy.py
+++ b/tasks/ceph_deploy.py
@@ -24,7 +24,8 @@ def download_ceph_deploy(ctx, config):
     """
     Downloads ceph-deploy from the ceph.com git mirror and (by default)
     switches to the master branch. If the `ceph-deploy-branch` is specified, it
-    will use that instead.
+    will use that instead. The `bootstrap` script is ran, with the argument
+    obtained from `python_version`, if specified.
     """
     log.info('Downloading ceph-deploy...')
     testdir = teuthology.get_testdir(ctx)
@@ -38,14 +39,17 @@ def download_ceph_deploy(ctx, config):
             '{tdir}/ceph-deploy'.format(tdir=testdir),
         ],
     )
-    ceph_admin.run(
-        args=[
-            'cd',
-            '{tdir}/ceph-deploy'.format(tdir=testdir),
-            run.Raw('&&'),
-            './bootstrap',
-        ],
-    )
+    args = [
+        'cd',
+        '{tdir}/ceph-deploy'.format(tdir=testdir),
+        run.Raw('&&'),
+        './bootstrap',
+    ]
+    try:
+        args.append(str(config['python_version']))
+    except KeyError:
+        pass
+    ceph_admin.run(args=args)
 
     try:
         yield


### PR DESCRIPTION
This is tightly related to https://github.com/ceph/ceph-deploy/pull/388 (Python 3 Compatibility of ceph-deploy).
- The changes to the QA suite are needed in order to test ceph-deploy under different Python versions (here only major versions are specified - 2 or 3). If the *python_version* is not specified, nothing will be installed and the default *python* executable will be used (basically old behavior).
- And in turn, this pull request relies on the change of the bootstrap script in ceph-deploy, and, of course, the Python 3 compatibility is the new feature that is tested here.

Here are some sepia test runs under these changes:

- http://pulpito.ceph.com/oprypin-2016-06-16_08:41:28-ceph-deploy-jewel---basic-mira/
- http://pulpito.ceph.com/oprypin-2016-06-17_10:12:39-ceph-deploy-jewel---basic-mira/
- http://pulpito.ceph.com/oprypin-2016-06-20_15:51:37-ceph-deploy-jewel---basic-mira/
- http://pulpito.ceph.com/oprypin-2016-06-21_13:09:06-ceph-deploy-jewel---basic-mira/ 

There are failures but they seem to be caused by something else (such failures were known to happen before)
http://tracker.ceph.com/issues/16405