### PR TITLE
[ec_]lost_unfound: don't flush_pg_stats at the beginning

### DIFF
--- a/tasks/ec_lost_unfound.py
+++ b/tasks/ec_lost_unfound.py
@@ -29,10 +29,6 @@ def task(ctx, config):
         logger=log.getChild('ceph_manager'),
         )
 
-    manager.raw_cluster_cmd('tell', 'osd.0', 'flush_pg_stats')
-    manager.raw_cluster_cmd('tell', 'osd.1', 'flush_pg_stats')
-    manager.raw_cluster_cmd('tell', 'osd.2', 'flush_pg_stats')
-    manager.raw_cluster_cmd('tell', 'osd.3', 'flush_pg_stats')
     manager.wait_for_clean()
 
     profile = config.get('erasure_code_profile', {

--- a/tasks/lost_unfound.py
+++ b/tasks/lost_unfound.py
@@ -32,9 +32,7 @@ def task(ctx, config):
 
     while len(manager.get_osd_status()['up']) < 3:
         time.sleep(10)
-    manager.raw_cluster_cmd('tell', 'osd.0', 'flush_pg_stats')
-    manager.raw_cluster_cmd('tell', 'osd.1', 'flush_pg_stats')
-    manager.raw_cluster_cmd('tell', 'osd.2', 'flush_pg_stats')
+
     manager.wait_for_clean()
 
     manager.create_pool(POOL)


### PR DESCRIPTION
The upgrade tests restart the daemons right before that part, and the
restart marks the osds down causing the flush_pg_stats to fail.  It's
not necessary anymore anyway.

Signed-off-by: Samuel Just <sjust@redhat.com>