### PR TITLE
short_pg_log: double params to avoid failures from dup detection failure

### DIFF
--- a/overrides/short_pg_log.yaml
+++ b/overrides/short_pg_log.yaml
@@ -2,5 +2,5 @@ overrides:
   ceph:
     conf:
       global:
-        osd_min_pg_log_entries: 150
-        osd_max_pg_log_entries: 300
+        osd_min_pg_log_entries: 300
+        osd_max_pg_log_entries: 600


### PR DESCRIPTION
Signed-off-by: Samuel Just <sjust@redhat.com>