### PR TITLE
rados/thrash/workloads/cache-agent-big: set min_size=2 on m=1 k=2 ec pool

### DIFF
--- a/suites/rados/thrash/workloads/cache-agent-big.yaml
+++ b/suites/rados/thrash/workloads/cache-agent-big.yaml
@@ -7,6 +7,7 @@ tasks:
     client.0:
       - sudo ceph osd erasure-code-profile set teuthologyprofile ruleset-failure-domain=osd m=1 k=2
       - sudo ceph osd pool create base 4 4 erasure teuthologyprofile
+      - sudo ceph osd pool set base min_size 2
       - sudo ceph osd pool create cache 4
       - sudo ceph osd tier add base cache
       - sudo ceph osd tier cache-mode cache writeback


### PR DESCRIPTION
Otherwise min_size will be 3 and we will wedge on a single down
osd.

Signed-off-by: Sage Weil <sage@redhat.com>