### PR TITLE
cephfs: add test for dump tree admin socket command

### DIFF
--- a/suites/fs/basic/tasks/asok_dump_tree.yaml
+++ b/suites/fs/basic/tasks/asok_dump_tree.yaml
@@ -1,0 +1,7 @@
+tasks:
+- install:
+- ceph:
+- ceph-fuse:
+- cephfs_test_runner:
+    modules:
+      - tasks.cephfs.test_dump_tree

--- a/tasks/cephfs/mount.py
+++ b/tasks/cephfs/mount.py
@@ -528,15 +528,24 @@ class CephFSMount(object):
         proc = self._run_python(pyscript)
         proc.wait()
 
-    def path_to_ino(self, fs_path):
+    def path_to_ino(self, fs_path, follow_symlinks=True):
         abs_path = os.path.join(self.mountpoint, fs_path)
 
-        pyscript = dedent("""
-            import os
-            import stat
+        if follow_symlinks:
+            pyscript = dedent("""
+                import os
+                import stat
 
-            print os.stat("{path}").st_ino
-            """).format(path=abs_path)
+                print os.stat("{path}").st_ino
+                """).format(path=abs_path)
+        else:
+            pyscript = dedent("""
+                import os
+                import stat
+
+                print os.lstat("{path}").st_ino
+                """).format(path=abs_path)
+
         proc = self._run_python(pyscript)
         proc.wait()
         return int(proc.stdout.getvalue().strip())

--- a/tasks/cephfs/test_dump_tree.py
+++ b/tasks/cephfs/test_dump_tree.py
@@ -1,0 +1,66 @@
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
+import random
+import os
+
+class TestDumpTree(CephFSTestCase):
+    def get_paths_to_ino(self):
+        inos = {}
+        p = self.mount_a.run_shell(["find", "./"])
+        paths = p.stdout.getvalue().strip().split()
+        for path in paths:
+            inos[path] = self.mount_a.path_to_ino(path, False)
+
+        return inos
+
+    def populate(self):
+        self.mount_a.run_shell(["git", "clone",
+                                "https://github.com/ceph/ceph-qa-suite"])
+
+    def test_basic(self):
+        self.mount_a.run_shell(["mkdir", "parent"])
+        self.mount_a.run_shell(["mkdir", "parent/child"])
+        self.mount_a.run_shell(["touch", "parent/child/file"])
+        self.mount_a.run_shell(["mkdir", "parent/child/grandchild"])
+        self.mount_a.run_shell(["touch", "parent/child/grandchild/file"])
+
+        inos = self.get_paths_to_ino()
+        tree = self.fs.mds_asok(["dump", "tree", "/parent/child", "1"])
+
+        target_inos = [inos["./parent/child"], inos["./parent/child/file"],
+                       inos["./parent/child/grandchild"]]
+
+        for ino in tree:
+            del target_inos[target_inos.index(ino['ino'])] # don't catch!
+            
+        assert(len(target_inos) == 0)
+
+    def test_random(self):
+        random.seed(0)
+
+        self.populate()
+        inos = self.get_paths_to_ino()
+        target = random.choice(inos.keys())
+
+        if target != "./":
+            target = os.path.dirname(target)
+
+        subtree = [path for path in inos.keys() if path.startswith(target)]
+        target_inos = [inos[path] for path in subtree]
+        tree = self.fs.mds_asok(["dump", "tree", target[1:]])
+
+        for ino in tree:
+            del target_inos[target_inos.index(ino['ino'])] # don't catch!
+            
+        assert(len(target_inos) == 0)
+
+        target_depth = target.count('/')
+        maxdepth = max([path.count('/') for path in subtree]) - target_depth
+        depth = random.randint(0, maxdepth)
+        target_inos = [inos[path] for path in subtree \
+                       if path.count('/') <= depth + target_depth]
+        tree = self.fs.mds_asok(["dump", "tree", target[1:], str(depth)])
+
+        for ino in tree:
+            del target_inos[target_inos.index(ino['ino'])] # don't catch!
+            
+        assert(len(target_inos) == 0)


### PR DESCRIPTION
Add test_dump_tree to validate the MDS admin socket command
dump tree. Add a parameter for path_to_ino to enable the use of
lstat() instead of stat()

See: http://tracker.ceph.com/issues/11171
See: https://github.com/ceph/ceph/pull/9925
Signed-off-by: Douglas Fuller <dfuller@redhat.com>