### PR TITLE
cephfs: test fragment size limit

### DIFF
--- a/suites/fs/basic/dirfrag/frag_enable.yaml
+++ b/suites/fs/basic/dirfrag/frag_enable.yaml
@@ -4,6 +4,7 @@ overrides:
     conf:
       mds:
         mds bal frag: true
+        mds bal fragment size max: 10000
         mds bal split size: 100
         mds bal merge size: 5
         mds bal split bits: 3


### PR DESCRIPTION
The fragment configuration uses 10000 for the fragment max size. The reason for
this is that many tests add 1000 files to a single directory which will hit
this limit without fragmentation catching up.

The test_dirfrag_limit test confirms:

o That the directory fragment size cannot exceed mds_bal_fragment_size_max (using a limit of 50 in all configurations).
o That fragmentation (forced) will allow more entries to be created.
o That unlink fails when the stray directory fragment becomes too large and that unlinking may continue once those strays are purged.

Tests: https://github.com/ceph/ceph/pull/9789
Issue: http://tracker.ceph.com/issues/16164

Signed-off-by: Patrick Donnelly <batrick@batbytes.com>