### PR TITLE
jewel: packages.yaml: drop ceph-devel

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -33,7 +33,6 @@ ceph:
   rpm:
   - ceph-radosgw
   - ceph-test
-  - ceph-devel
   - ceph
   - ceph-fuse
   - cephfs-java


### PR DESCRIPTION
There are no "-dev" packages listed in the deb section of this file, so it
serves no purpose to have ceph-devel here.

Also, once https://github.com/ceph/ceph/pull/9744 is merged the presence of
"ceph-devel" in this file will break teuthology for rpm targets.

Signed-off-by: Nathan Cutler ncutler@suse.com
(cherry picked from commit af9e05709af76c931e4dd50349cac3a4fc87a575)
