### PR TITLE
hammer: Testing: SIGABRT in TrackedOp::dump() via dump_ops_in_flight()

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -114,6 +114,7 @@ class Thrasher:
         self.chance_move_pg = self.config.get('chance_move_pg', 1.0)
         self.optrack_toggle_delay = self.config.get('optrack_toggle_delay')
         self.dump_ops_enable = self.config.get('dump_ops_enable')
+        self.noscrub_toggle_delay = self.config.get('noscrub_toggle_delay')
 
         num_osds = self.in_osds + self.out_osds
         self.max_pgs = self.config.get("max_pgs_per_pool_osd", 1200) * num_osds
@@ -141,6 +142,8 @@ class Thrasher:
             self.optrack_toggle_thread = gevent.spawn(self.do_optrack_toggle)
         if self.dump_ops_enable == "true":
             self.dump_ops_thread = gevent.spawn(self.do_dump_ops)
+        if self.noscrub_toggle_delay:
+            self.noscrub_toggle_thread = gevent.spawn(self.do_noscrub_toggle)
         if self.config.get('powercycle') or not self.cmd_exists_on_osds("ceph-objectstore-tool"):
             self.ceph_objectstore_tool = False
             self.test_rm_past_intervals = False
@@ -437,6 +440,9 @@ class Thrasher:
         if self.dump_ops_enable == "true":
             self.log("joining the do_dump_ops greenlet")
             self.dump_ops_thread.join()
+        if self.noscrub_toggle_delay:
+            self.log("joining the do_noscrub_toggle greenlet")
+            self.noscrub_toggle_thread.join()
 
     def grow_pool(self):
         """
@@ -689,6 +695,33 @@ class Thrasher:
                 self.ceph_manager.osd_admin_socket(osd, command=['dump_historic_ops'],
                                      check_status=False, timeout=30)
             gevent.sleep(0)
+
+    @log_exc
+    def do_noscrub_toggle(self):
+        """
+        Loops and toggle noscrub flags
+
+        Loop delay is controlled by the config value noscrub_toggle_delay.
+        """
+        delay = float(self.noscrub_toggle_delay)
+        scrub_state = "none"
+        self.log("starting do_noscrub_toggle with a delay of {0}".format(delay))
+        while not self.stopping:
+            if scrub_state == "none":
+                self.ceph_manager.raw_cluster_cmd('osd', 'set', 'noscrub')
+                scrub_state = "noscrub"
+            elif scrub_state == "noscrub":
+                self.ceph_manager.raw_cluster_cmd('osd', 'set', 'nodeep-scrub')
+                scrub_state = "both"
+            elif scrub_state == "both":
+                self.ceph_manager.raw_cluster_cmd('osd', 'unset', 'noscrub')
+                scrub_state = "nodeep-scrub"
+            else:
+                self.ceph_manager.raw_cluster_cmd('osd', 'unset', 'nodeep-scrub')
+                scrub_state = "none"
+            gevent.sleep(delay)
+        self.ceph_manager.raw_cluster_cmd('osd', 'unset', 'noscrub')
+        self.ceph_manager.raw_cluster_cmd('osd', 'unset', 'nodeep-scrub')
 
     @log_exc
     def do_thrash(self):

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -675,7 +675,9 @@ class Thrasher:
                 osd_state = "false"
             else:
                 osd_state = "true"
-            self.ceph_manager.raw_cluster_cmd_result('tell', 'osd.*',
+            for osd in self.live_osds:
+                osdname = "osd.{o}".format(o=osd)
+                self.ceph_manager.raw_cluster_cmd_result('tell', osdname,
                              'injectargs', '--osd_enable_op_tracker=%s' % osd_state)
             gevent.sleep(delay)
 

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -875,8 +875,8 @@ class CephManager:
                 ]
             )
 
-    def osd_admin_socket(self, osd_id, command, check_status=True):
-        return self.admin_socket('osd', osd_id, command, check_status)
+    def osd_admin_socket(self, osd_id, command, check_status=True, timeout=0):
+        return self.admin_socket('osd', osd_id, command, check_status, timeout)
 
     def find_remote(self, service_type, service_id):
         """
@@ -897,7 +897,7 @@ class CephManager:
                                                           service_id))
 
     def admin_socket(self, service_type, service_id,
-                     command, check_status=True):
+                     command, check_status=True, timeout=0):
         """
         Remotely start up ceph specifying the admin socket
         :param command: a list of words to use as the command
@@ -910,6 +910,8 @@ class CephManager:
             'adjust-ulimits',
             'ceph-coverage',
             '{tdir}/archive/coverage'.format(tdir=testdir),
+            'timeout',
+            str(timeout),
             'ceph',
             '--admin-daemon',
             '/var/run/ceph/ceph-{type}.{id}.asok'.format(

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -112,6 +112,8 @@ class Thrasher:
         self.clean_wait = self.config.get('clean_wait', 0)
         self.minin = self.config.get("min_in", 3)
         self.chance_move_pg = self.config.get('chance_move_pg', 1.0)
+        self.optrack_toggle_delay = self.config.get('optrack_toggle_delay')
+        self.dump_ops_enable = self.config.get('dump_ops_enable')
 
         num_osds = self.in_osds + self.out_osds
         self.max_pgs = self.config.get("max_pgs_per_pool_osd", 1200) * num_osds
@@ -135,6 +137,10 @@ class Thrasher:
             manager.raw_cluster_cmd('--', 'mon', 'tell', '*', 'injectargs',
                                     '--mon-osd-down-out-interval 0')
         self.thread = gevent.spawn(self.do_thrash)
+        if self.optrack_toggle_delay:
+            self.optrack_toggle_thread = gevent.spawn(self.do_optrack_toggle)
+        if self.dump_ops_enable == "true":
+            self.dump_ops_thread = gevent.spawn(self.do_dump_ops)
         if self.config.get('powercycle') or not self.cmd_exists_on_osds("ceph-objectstore-tool"):
             self.ceph_objectstore_tool = False
             self.test_rm_past_intervals = False
@@ -425,6 +431,12 @@ class Thrasher:
         """
         self.stopping = True
         self.thread.get()
+        if self.optrack_toggle_delay:
+            self.log("joining the do_optrack_toggle greenlet")
+            self.optrack_toggle_thread.join()
+        if self.dump_ops_enable == "true":
+            self.log("joining the do_dump_ops greenlet")
+            self.dump_ops_thread.join()
 
     def grow_pool(self):
         """
@@ -641,6 +653,42 @@ class Thrasher:
                 self.log(traceback.format_exc())
                 raise
         return wrapper
+
+    @log_exc
+    def do_optrack_toggle(self):
+        """
+        Loops and toggle op tracking to all osds.
+
+        Loop delay is controlled by the config value optrack_toggle_delay.
+        """
+        delay = float(self.optrack_toggle_delay)
+        osd_state = "true"
+        self.log("starting do_optrack_toggle with a delay of {0}".format(delay))
+        while not self.stopping:
+            if osd_state == "true":
+                osd_state = "false"
+            else:
+                osd_state = "true"
+            self.ceph_manager.raw_cluster_cmd_result('tell', 'osd.*',
+                             'injectargs', '--osd_enable_op_tracker=%s' % osd_state)
+            gevent.sleep(delay)
+
+    @log_exc
+    def do_dump_ops(self):
+        """
+        Loops and does op dumps on all osds
+        """
+        self.log("starting do_dump_ops")
+        while not self.stopping:
+            for osd in self.live_osds:
+                # Ignore errors because live_osds is in flux
+                self.ceph_manager.osd_admin_socket(osd, command=['dump_ops_in_flight'],
+                                     check_status=False, timeout=30)
+                self.ceph_manager.osd_admin_socket(osd, command=['dump_blocked_ops'],
+                                     check_status=False, timeout=30)
+                self.ceph_manager.osd_admin_socket(osd, command=['dump_historic_ops'],
+                                     check_status=False, timeout=30)
+            gevent.sleep(0)
 
     @log_exc
     def do_thrash(self):

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -864,6 +864,8 @@ class CephManager:
             'adjust-ulimits',
             'ceph-coverage',
             '{tdir}/archive/coverage'.format(tdir=testdir),
+            'timeout',
+            '120',
             'ceph',
         ]
         ceph_args.extend(args)
@@ -882,6 +884,8 @@ class CephManager:
             'adjust-ulimits',
             'ceph-coverage',
             '{tdir}/archive/coverage'.format(tdir=testdir),
+            'timeout',
+            '120',
             'ceph',
         ]
         ceph_args.extend(args)

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -19,6 +19,10 @@ from util.rados import cmd_erasure_code_profile
 from teuthology.orchestra.remote import Remote
 from teuthology.orchestra import run
 
+try:
+    from subprocess import DEVNULL # py3k
+except ImportError:
+    DEVNULL = open(os.devnull, 'r+')
 
 DEFAULT_CONF_PATH = '/etc/ceph/ceph.conf'
 
@@ -691,11 +695,11 @@ class Thrasher:
             for osd in self.live_osds:
                 # Ignore errors because live_osds is in flux
                 self.ceph_manager.osd_admin_socket(osd, command=['dump_ops_in_flight'],
-                                     check_status=False, timeout=30)
+                                     check_status=False, timeout=30, stdout=DEVNULL)
                 self.ceph_manager.osd_admin_socket(osd, command=['dump_blocked_ops'],
-                                     check_status=False, timeout=30)
+                                     check_status=False, timeout=30, stdout=DEVNULL)
                 self.ceph_manager.osd_admin_socket(osd, command=['dump_historic_ops'],
-                                     check_status=False, timeout=30)
+                                     check_status=False, timeout=30, stdout=DEVNULL)
             gevent.sleep(0)
 
     @log_exc
@@ -808,14 +812,14 @@ class ObjectStoreTool:
         lines.append(cmd)
         return "\n".join(lines)
 
-    def run(self, options, args, stdin=None):
+    def run(self, options, args, stdin=None, stdout=StringIO()):
         self.manager.kill_osd(self.osd)
         cmd = self.build_cmd(options, args, stdin)
         self.manager.log(cmd)
         try:
             proc = self.remote.run(args=['bash', '-e', '-x', '-c', cmd],
                                    check_status=False,
-                                   stdout=StringIO(),
+                                   stdout=stdout,
                                    stderr=StringIO())
             proc.wait()
             if proc.exitstatus != 0:
@@ -962,8 +966,8 @@ class CephManager:
                 ]
             )
 
-    def osd_admin_socket(self, osd_id, command, check_status=True, timeout=0):
-        return self.admin_socket('osd', osd_id, command, check_status, timeout)
+    def osd_admin_socket(self, osd_id, command, check_status=True, timeout=0, stdout=StringIO()):
+        return self.admin_socket('osd', osd_id, command, check_status, timeout, stdout)
 
     def find_remote(self, service_type, service_id):
         """
@@ -984,7 +988,7 @@ class CephManager:
                                                           service_id))
 
     def admin_socket(self, service_type, service_id,
-                     command, check_status=True, timeout=0):
+                     command, check_status=True, timeout=0, stdout=StringIO()):
         """
         Remotely start up ceph specifying the admin socket
         :param command: a list of words to use as the command
@@ -1008,7 +1012,7 @@ class CephManager:
         args.extend(command)
         return remote.run(
             args=args,
-            stdout=StringIO(),
+            stdout=stdout,
             wait=True,
             check_status=check_status
             )

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -1087,7 +1087,7 @@ class CephManager:
             '0')
 
     def wait_run_admin_socket(self, service_type,
-                              service_id, args=['version'], timeout=75):
+                              service_id, args=['version'], timeout=75, stdout=StringIO()):
         """
         If osd_admin_socket call suceeds, return.  Otherwise wait
         five seconds and try again.
@@ -1095,7 +1095,7 @@ class CephManager:
         tries = 0
         while True:
             proc = self.admin_socket(service_type, service_id,
-                                     args, check_status=False)
+                                     args, check_status=False, stdout=stdout)
             if proc.exitstatus is 0:
                 break
             else:
@@ -1809,7 +1809,7 @@ class CephManager:
         # unhappy.  see #5924.
         self.wait_run_admin_socket('osd', osd,
                                    args=['dump_ops_in_flight'],
-                                   timeout=timeout)
+                                   timeout=timeout, stdout=DEVNULL)
 
     def mark_down_osd(self, osd):
         """

--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -2,6 +2,7 @@
 ceph manager -- Thrasher and CephManager objects
 """
 from cStringIO import StringIO
+from functools import wraps
 import contextlib
 import random
 import time
@@ -10,6 +11,7 @@ import base64
 import json
 import logging
 import threading
+import traceback
 import os
 from teuthology import misc as teuthology
 from tasks.scrub import Scrubber
@@ -630,6 +632,17 @@ class Thrasher:
             val -= prob
         return None
 
+    def log_exc(func):
+        @wraps(func)
+        def wrapper(self):
+            try:
+                return func(self)
+            except:
+                self.log(traceback.format_exc())
+                raise
+        return wrapper
+
+    @log_exc
     def do_thrash(self):
         """
         Loop to select random actions to thrash ceph manager with.

--- a/tasks/thrashosds.py
+++ b/tasks/thrashosds.py
@@ -97,6 +97,11 @@ def task(ctx, config):
     ceph_objectstore_tool: (true) whether to export/import a pg while an osd is down
     chance_move_pg: (1.0) chance of moving a pg if more than 1 osd is down (default 100%)
 
+    optrack_toggle_delay: (2.0) duration to delay between toggling op tracker
+                  enablement to all osds
+
+    dump_ops_enable: (true) continuously dump ops on all live osds
+
     example:
 
     tasks:
@@ -112,6 +117,10 @@ def task(ctx, config):
         config = {}
     assert isinstance(config, dict), \
         'thrashosds task only accepts a dict for configuration'
+    # add default value for optrack_toggle_delay
+    config['optrack_toggle_delay'] = config.get('optrack_toggle_delay', 2.0)
+    # add default value for dump_ops_enable
+    config['dump_ops_enable'] = config.get('dump_ops_enable', "true")
     overrides = ctx.config.get('overrides', {})
     teuthology.deep_merge(config, overrides.get('thrashosds', {}))
 

--- a/tasks/thrashosds.py
+++ b/tasks/thrashosds.py
@@ -102,6 +102,8 @@ def task(ctx, config):
 
     dump_ops_enable: (true) continuously dump ops on all live osds
 
+    noscrub_toggle_delay: (2.0) duration to delay between toggling noscrub
+
     example:
 
     tasks:
@@ -121,6 +123,8 @@ def task(ctx, config):
     config['optrack_toggle_delay'] = config.get('optrack_toggle_delay', 2.0)
     # add default value for dump_ops_enable
     config['dump_ops_enable'] = config.get('dump_ops_enable', "true")
+    # add default value for noscrub_toggle_delay
+    config['noscrub_toggle_delay'] = config.get('noscrub_toggle_delay', 2.0)
     overrides = ctx.config.get('overrides', {})
     teuthology.deep_merge(config, overrides.get('thrashosds', {}))
 


### PR DESCRIPTION
Backport 3 pull requests and add fix specifically for Hammer not to use osd.\* since it crashes the command.

ceph/ceph-qa-suite#344
ceph/ceph-qa-suite#911
ceph/ceph-qa-suite#1122
