### PR TITLE
task/packages: install libcephfs1-dev

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -9,6 +9,7 @@ ceph:
   - radosgw
   - python-ceph
   - libcephfs1
+  - libcephfs-dev
   - libcephfs-java
   - libcephfs-jni
   - librados2
@@ -37,6 +38,7 @@ ceph:
   - cephfs-java
   - libcephfs_jni1
   - libcephfs1
+  - libcephfs1-devel
   - librados2
   - librbd1
   - python-rados


### PR DESCRIPTION
The way we currently build the cephfs java
bindings depends on the unversioned .so file
which is in the -dev package, not the
main one.

Fixes: http://tracker.ceph.com/issues/16640
Signed-off-by: John Spray <john.spray@redhat.com>