### PR TITLE
ec_lost_unfound: set min_size to 2

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -1258,7 +1258,8 @@ class CephManager:
             self.raw_cluster_cmd(*args)
 
     def create_pool_with_unique_name(self, pg_num=16,
-                                     erasure_code_profile_name=None):
+                                     erasure_code_profile_name=None,
+                                     min_size=None):
         """
         Create a pool named unique_pool_X where X is unique.
         """
@@ -1269,7 +1270,8 @@ class CephManager:
             self.create_pool(
                 name,
                 pg_num,
-                erasure_code_profile_name=erasure_code_profile_name)
+                erasure_code_profile_name=erasure_code_profile_name,
+                min_size=min_size)
         return name
 
     @contextlib.contextmanager
@@ -1279,7 +1281,8 @@ class CephManager:
         self.remove_pool(pool_name)
 
     def create_pool(self, pool_name, pg_num=16,
-                    erasure_code_profile_name=None):
+                    erasure_code_profile_name=None,
+                    min_size=None):
         """
         Create a pool named from the pool_name parameter.
         :param pool_name: name of the pool being created.
@@ -1299,6 +1302,11 @@ class CephManager:
             else:
                 self.raw_cluster_cmd('osd', 'pool', 'create',
                                      pool_name, str(pg_num))
+            if min_size is not None:
+                self.raw_cluster_cmd(
+                    'osd', 'pool', 'set', pool_name,
+                    'min_size',
+                    str(min_size))
             self.pools[pool_name] = pg_num
         time.sleep(1)
 

--- a/tasks/ec_lost_unfound.py
+++ b/tasks/ec_lost_unfound.py
@@ -38,7 +38,9 @@ def task(ctx, config):
     })
     profile_name = profile.get('name', 'lost_unfound')
     manager.create_erasure_code_profile(profile_name, profile)
-    pool = manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)
+    pool = manager.create_pool_with_unique_name(
+        erasure_code_profile_name=profile_name,
+        min_size=2)
 
     # something that is always there, readable and never empty
     dummyfile = '/etc/group'


### PR DESCRIPTION
We changed the default to k+1 instead of k.  Adjust test to compensate.

Fixes: http://tracker.ceph.com/issues/16416
Signed-off-by: Samuel Just <sjust@redhat.com>