### PR TITLE
packages/packages.yaml: drop ceph-fs-common-dbg

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -15,7 +15,6 @@ ceph:
   - librbd1
   - rbd-fuse
   - ceph-common-dbg
-  - ceph-fs-common-dbg
   - ceph-fuse-dbg
   - ceph-mds-dbg
   - ceph-mon-dbg


### PR DESCRIPTION
Meant to be merged together with https://github.com/ceph/ceph/pull/10433

Fixes: http://tracker.ceph.com/issues/16808
Signed-off-by: Nathan Cutler <ncutler@suse.com>