### PR TITLE
Fix rechecking of health in loop

### DIFF
--- a/tasks/ceph_deploy.py
+++ b/tasks/ceph_deploy.py
@@ -598,6 +598,7 @@ def cli_test(ctx, config):
                                 action='check health') as proceed:
        while proceed():
            r = remote.run(args=['sudo', 'ceph', 'health'], stdout=StringIO())
+           out = r.stdout.getvalue()
            if (out.split(None,1)[0] == 'HEALTH_OK'):
                break
     rgw_install = 'install {branch} --rgw {node}'.format(


### PR DESCRIPTION
Use the newer stdout value for checking
ceph health again.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>