### PR TITLE
fs: fuse_default_permissions = 0 for kernel build test

### DIFF
--- a/suites/fs/basic/tasks/cfuse_workunit_kernel_untar_build.yaml
+++ b/suites/fs/basic/tasks/cfuse_workunit_kernel_untar_build.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        fuse_default_permissions: 0
 tasks:
 - ceph-fuse:
 - workunit:


### PR DESCRIPTION
Ported from Zheng's #22: 2e283ce6d77c66a564d807f0b0909b238c4fb5f0

"This can reduce the test time becuase it avoids sending getattr request
whenever the kernel checks inode permission."

This is part of an effort to eliminate unnecessary differences between
multimds and fs suites.

Signed-off-by: Patrick Donnelly <batrick@batbytes.com>