### PR TITLE
cephfs/vstart_runner: add -w option to ps

### DIFF
--- a/tasks/cephfs/vstart_runner.py
+++ b/tasks/cephfs/vstart_runner.py
@@ -257,7 +257,7 @@ class LocalDaemon(object):
         Return PID as an integer or None if not found
         """
         ps_txt = self.controller.run(
-            args=["ps", "-xu"+str(os.getuid())]
+            args=["ps", "-xwwu"+str(os.getuid())]
         ).stdout.getvalue().strip()
         lines = ps_txt.split("\n")[1:]
 


### PR DESCRIPTION
vstart_runner can't find arguments to ceph daemons to identify them with
ps -x because commands are cut off at terminal width. Add -w for wide
output.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>