### PR TITLE
suites/upgrade: point-to-point Jewel upgrade workaround

### DIFF
--- a/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
+++ b/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
@@ -153,6 +153,8 @@ workload_x:
          client.1:
          - rados/test-upgrade-v11.0.0.sh
          - cls
+       env:
+         CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_image'
    - print: "**** done rados/test-upgrade-v11.0.0.sh &  cls workload_x NOT upgraded  client"
    - workunit:
        branch: jewel


### PR DESCRIPTION
The v10.2.x cls_rbd test case will not pass against a v10.2.0
OSD. Disable the offending test.

Fixes: http://tracker.ceph.com/issues/16529
Signed-off-by: Jason Dillaman <dillaman@redhat.com>