### PR TITLE
rgw: data_extra_pool is unique per zone

### DIFF
--- a/tasks/radosgw_admin.py
+++ b/tasks/radosgw_admin.py
@@ -277,8 +277,10 @@ def task(ctx, config):
                 check_status=True)
             del out1['data']['bucket_info']['bucket']['pool']
             del out1['data']['bucket_info']['bucket']['index_pool']
+            del out1['data']['bucket_info']['bucket']['data_extra_pool']
             del out2['data']['bucket_info']['bucket']['pool']
             del out2['data']['bucket_info']['bucket']['index_pool']
+            del out2['data']['bucket_info']['bucket']['data_extra_pool']
             assert out1 == out2
 
         same_region = 0


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17025
Signed-off-by: Orit Wasserman <owasserm@redhat.com>
(cherry picked from commit c6cdd0905fbb3a9571400a5227b34b7e2e738830)