### PR TITLE
Add the option to run rados tests on Python 3

### DIFF
--- a/suites/rados/basic/tasks/rados_python3.yaml
+++ b/suites/rados/basic/tasks/rados_python3.yaml
@@ -1,0 +1,15 @@
+tasks:
+- install:
+    extra_packages: [python3-rados]
+- exec:
+    all:
+      - 'sudo sed -i -e "1s,^\(#!/usr/bin.*python\)[0-9]*$,\13," /usr/bin/ceph'
+- ceph:
+    log-whitelist:
+    - wrongly marked me down
+- workunit:
+    env:
+      PYTHON: python3
+    clients:
+      client.0:
+        - rados/test_python.sh

--- a/suites/rados/singleton/all/cephtool-python3.yaml
+++ b/suites/rados/singleton/all/cephtool-python3.yaml
@@ -12,9 +12,10 @@ openstack:
       size: 10 # GB
 tasks:
 - install:
+    extra_packages: [python3-cephfs, python3-rados, python3-rbd]
 - exec:
     all:
-      - 'sudo sed -i -e "1s,^\(#!/usr/bin.*python\)[0-9]*$,\12," /usr/bin/ceph'
+      - 'sudo sed -i -e "1s,^\(#!/usr/bin.*python\)[0-9]*$,\13," /usr/bin/ceph'
 - ceph:
     log-whitelist:
     - wrongly marked me down

--- a/suites/rados/thrash/versions/python2.yaml
+++ b/suites/rados/thrash/versions/python2.yaml
@@ -1,0 +1,4 @@
+tasks:
+- exec:
+    all:
+      - 'sudo sed -i -e "1s,^\(#!/usr/bin.*python\)[0-9]*$,\12," /usr/bin/ceph'

--- a/suites/rados/thrash/versions/python3.yaml
+++ b/suites/rados/thrash/versions/python3.yaml
@@ -1,0 +1,6 @@
+tasks:
+- install:
+    extra_packages: [python3-cephfs, python3-rados, python3-rbd]
+- exec:
+    all:
+      - 'sudo sed -i -e "1s,^\(#!/usr/bin.*python\)[0-9]*$,\13," /usr/bin/ceph'


### PR DESCRIPTION
This adds some test items to the rados suite that run Python 3 instead of Python 2.

A few notes:
- https://github.com/ceph/ceph/pull/10782 allows specifying the Python executable for _rados/test_python.sh_ as an environment variable
- https://github.com/ceph/teuthology/pull/922 allows installing the packages as just _python3-*_ although they're actually _python34-*_ on CentOS.
- The recurring `sed` usage replaces the hashbang of the _ceph_ script to contain `#!/usr/bin/python3`.
