### PR TITLE
ceph_manager: lower mon_reweight_min_bytes_per_osd to 10

### DIFF
--- a/tasks/ceph_manager.py
+++ b/tasks/ceph_manager.py
@@ -142,6 +142,8 @@ class Thrasher:
         except Exception:
             manager.raw_cluster_cmd('--', 'mon', 'tell', '*', 'injectargs',
                                     '--mon-osd-down-out-interval 0')
+        manager.raw_cluster_cmd('--', 'tell', 'mon.*', 'injectargs',
+                                '--mon-reweight-min-bytes-per-osd 10')
         self.thread = gevent.spawn(self.do_thrash)
         if self.sighup_delay:
             self.sighup_thread = gevent.spawn(self.do_sighup)


### PR DESCRIPTION
otherwise monitor could reject the command:
```
Refusing to reweight: we only used 588084 kb used across all osds!
```
if the average used space is smaller than
`mon_reweight_min_bytes_per_osd`.

Fixes: http://tracker.ceph.com/issues/16805
Signed-off-by: Kefu Chai <kchai@redhat.com>