### PR TITLE
Revert "packages.yaml: reflect python-ceph package split"

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -41,8 +41,6 @@ ceph:
   - libcephfs1-devel
   - librados2
   - librbd1
-  - python-rados
-  - python-rbd
-  - python-cephfs
+  - python-ceph
   - rbd-fuse
   - ceph-debuginfo


### PR DESCRIPTION
This reverts commit 0216330568fc1dec2e866bbfd1e49dc42266e1ab.

Fixes: http://tracker.ceph.com/issues/17075
Signed-off-by: Nathan Cutler <ncutler@suse.com>