### PR TITLE
Revert "packages.yaml: reflect python-ceph package split"

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -40,8 +40,6 @@ ceph:
   - libcephfs1
   - librados2
   - librbd1
-  - python-rados
-  - python-rbd
-  - python-cephfs
+  - python-ceph
   - rbd-fuse
   - ceph-debuginfo


### PR DESCRIPTION
This reverts commit ec4b0c3d6b057e688363d966a83a037c3585b32f.

References: http://tracker.ceph.com/issues/17075
Signed-off-by: Nathan Cutler <ncutler@suse.com>