### PR TITLE
[DNM] workunit: allow parallel git clone

### DIFF
--- a/tasks/workunit.py
+++ b/tasks/workunit.py
@@ -288,7 +288,7 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
     else:
         scratch_tmp = os.path.join(mnt, subdir)
     srcdir = '{tdir}/workunit.{role}'.format(tdir=testdir, role=role)
-    clonedir = '{tdir}/clone'.format(tdir=testdir)
+    clonedir = '{tdir}/clone.{role}'.format(tdir=testdir, role=role)
 
     git_url = teuth_config.get_ceph_git_url()
     if 'github.com/ceph/ceph' in git_url:


### PR DESCRIPTION
When multiple client run in parallel on the same machine and they
try to get workunits from a repository that is not github, they must
git clone in a directory that is suffixed as srcdir. Otherwise they
will conflict with each other.

Fixes: http://tracker.ceph.com/issues/17116

Signed-off-by: Loic Dachary <loic@dachary.org>
(cherry picked from commit b9813e490ec8a5bb59e177612f047899397c342e)