### PR TITLE
rados/objectstore/objectstore.yaml: skip bluestore tests

### DIFF
--- a/suites/rados/objectstore/objectstore.yaml
+++ b/suites/rados/objectstore/objectstore.yaml
@@ -8,5 +8,5 @@ tasks:
 - install:
 - exec:
     client.0:
-      - mkdir $TESTDIR/ostest && cd $TESTDIR/ostest && ceph_test_objectstore
+      - mkdir $TESTDIR/ostest && cd $TESTDIR/ostest && ceph_test_objectstore --gtest_filter=-*/2
       - rm -rf $TESTDIR/ostest


### PR DESCRIPTION
Avoid breaking rados suite while we are developing rapidly.

Signed-off-by: Sage Weil sage@redhat.com
(cherry picked from commit 11ee1a8cfdc85855df06375d56f741a3186db08d)
