### PR TITLE
tasks/ceph: construct CephManager earlier

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -1485,19 +1485,21 @@ def task(ctx, config):
     ]
 
     with contextutil.nested(*subtasks):
+        first_mon = teuthology.get_first_mon(ctx, config, config['cluster'])
+        (mon,) = ctx.cluster.only(first_mon).remotes.iterkeys()
+        if not hasattr(ctx, 'managers'):
+            ctx.managers = {}
+        ctx.managers[config['cluster']] = CephManager(
+            mon,
+            ctx=ctx,
+            logger=log.getChild('ceph_manager.' + config['cluster']),
+            cluster=config['cluster'],
+        )
+
         try:
             if config.get('wait-for-healthy', True):
                 healthy(ctx=ctx, config=dict(cluster=config['cluster']))
-            first_mon = teuthology.get_first_mon(ctx, config, config['cluster'])
-            (mon,) = ctx.cluster.only(first_mon).remotes.iterkeys()
-            if not hasattr(ctx, 'managers'):
-                ctx.managers = {}
-            ctx.managers[config['cluster']] = CephManager(
-                mon,
-                ctx=ctx,
-                logger=log.getChild('ceph_manager.' + config['cluster']),
-                cluster=config['cluster'],
-            )
+
             yield
         finally:
             if config.get('wait-for-scrub', True):


### PR DESCRIPTION
Previously, if errors occurred during healthy(), then
the finally block would invoke osd_scrub_pgs, which relies
on CephManager being constructed, and it would die, hiding
the original exception.

Signed-off-by: John Spray <john.spray@redhat.com>