### PR TITLE
krbd/unmap: put client.0 on a separate remote

### DIFF
--- a/suites/krbd/unmap/clusters/fixed-1.yaml
+++ b/suites/krbd/unmap/clusters/fixed-1.yaml
@@ -1,1 +1,0 @@
-../../../../clusters/fixed-1.yaml

--- a/suites/krbd/unmap/clusters/separate-client.yaml
+++ b/suites/krbd/unmap/clusters/separate-client.yaml
@@ -1,0 +1,12 @@
+# fixed-1.yaml, but with client.0 on a separate target
+overrides:
+  ceph-deploy:
+    conf:
+      global:
+        osd pool default size: 2
+        osd crush chooseleaf type: 0
+        osd pool default pg num:  128
+        osd pool default pgp num:  128
+roles:
+- [mon.a, osd.0, osd.1, osd.2]
+- [client.0]


### PR DESCRIPTION
Otherwise a pre-single-major kernel override is a headache,
particularly with non-standard yaml configs.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>