### PR TITLE
buildpackages/make-rpm.sh: use /etc/os-release

### DIFF
--- a/tasks/buildpackages/make-rpm.sh
+++ b/tasks/buildpackages/make-rpm.sh
@@ -43,10 +43,9 @@ source $(dirname $0)/common.sh
 
 init_ceph $git_ceph_url $sha1
 
-#id=$(lsb_release -s -i | tr A-Z a-z)
-#major=$(lsb_release -s -r | sed -s "s;\..*;;g")
-#codename="${id}${major}"
-releasedir=$base/$(lsb_release -si | tr ' ' '_')/WORKDIR
+distro=$( source /etc/os-release ; echo $ID )
+distro_version=$( source /etc/os-release ; echo $VERSION )
+releasedir=$base/$distro/WORKDIR
 #
 # git describe provides a version that is
 # a) human readable
@@ -67,7 +66,7 @@ function setup_rpmmacros() {
     if ! grep -q find_debuginfo_dwz_opts $HOME/.rpmmacros ; then
         echo '%_find_debuginfo_dwz_opts %{nil}' >> $HOME/.rpmmacros
     fi
-    if lsb_release -d -s | grep CentOS | grep -q 'release 7' ; then
+    if [ "x${distro}x" = "xcentosx" ] && echo $distro_version | grep -q '7' ; then
         if ! grep -q '%dist .el7' $HOME/.rpmmacros ; then
             echo '%dist .el7' >> $HOME/.rpmmacros
         fi

--- a/tasks/buildpackages/make-rpm.sh
+++ b/tasks/buildpackages/make-rpm.sh
@@ -118,7 +118,8 @@ function build_package() {
     cp ceph.spec ${buildarea}/SPECS
     mkdir -p ${buildarea}/RPMS
     mkdir -p ${buildarea}/BUILD
-    cp -a ceph-*.tar.bz2 ${buildarea}/SOURCES/.
+    CEPH_TARBALL=( ceph-*.tar.bz2 )
+    cp -a $CEPH_TARBALL ${buildarea}/SOURCES/.
     cp -a rpm/*.patch ${buildarea}/SOURCES || true
     (
         cd ${buildarea}/SPECS
@@ -129,6 +130,7 @@ function build_package() {
                  -e 's/%{epoch}://g' \
                  -e '/^Epoch:/d' \
                  -e 's/%bcond_with ceph_test_package/%bcond_without ceph_test_package/' \
+                 -e "s/^Source0:.*$/Source0: $CEPH_TARBALL/" \
                  ceph.spec
         fi
         buildarea=`readlink -fn ${releasedir}`   ### rpm wants absolute path

--- a/tasks/buildpackages/make-rpm.sh
+++ b/tasks/buildpackages/make-rpm.sh
@@ -101,16 +101,8 @@ function build_package() {
         #
         make dist-bzip2
     else
-        ##
-        # make-dist script suffixes the tarball with full version info,
-        # these transformations change version info to only include
-        # version number as is required by the ceph.spec file
-        #
-        cat make-dist \
-          | sed -e '0,/^outfile=/s//ver=`echo $version | cut -d - -f 1-1`\n&/' \
-          | sed -e 's/^\(outfile="ceph-$ver\)sion"/\1"/g' \
-                -e 's/\(--prefix ceph-$ver\)sion/\1/g' \
-          | sh
+        # kraken and above
+        ./make-dist
     fi
     # Set up build area
     setup_rpmmacros


### PR DESCRIPTION
The lsb_release binary is deprecated and requires installation of packages.

The /etc/os-release file is guaranteed to be present.

Signed-off-by: Nathan Cutler ncutler@suse.com
