### PR TITLE
rados/singleton-nomsgr/all/11429: wait until clean before checking log

### DIFF
--- a/suites/rados/singleton-nomsgr/all/11429.yaml
+++ b/suites/rados/singleton-nomsgr/all/11429.yaml
@@ -71,10 +71,10 @@ tasks:
         - osd.0
         - osd.1
         - osd.2
+  - ceph_manager.wait_for_clean: null
   - exec:
       osd.0:
         - sudo grep -c 'load_pgs. skipping PG' /var/log/ceph/ceph-osd.0.log
-  - ceph_manager.wait_for_clean: null
   - ceph_manager.create_pool:
       args: ['newpool']
   - loop:


### PR DESCRIPTION
to make sure that load_pgs() is finished before checking its output

Fixes: http://tracker.ceph.com/issues/16157
Signed-off-by: Kefu Chai <kchai@redhat.com>