### PR TITLE
upgrade: ceph-test is needed for ceph-coverage

### DIFF
--- a/suites/upgrade/client-upgrade/hammer-client-x/basic/1-install/hammer-client-x.yaml
+++ b/suites/upgrade/client-upgrade/hammer-client-x/basic/1-install/hammer-client-x.yaml
@@ -5,6 +5,6 @@ tasks:
 upgrade_workload:
   sequential:
   - install.upgrade:
-      exclude_packages: ['ceph-test', 'ceph-test-dbg']
+      exclude_packages: ['ceph-test-dbg']
       client.0:
   - print: "**** done install.upgrade client.0"


### PR DESCRIPTION
Do not exclude the ceph-test package otherwise the ceph-coverage
executable is not installed.

Fixes: http://tracker.ceph.com/issues/16506

Signed-off-by: Loic Dachary <loic@dachary.org>