### PR TITLE
Add ceph-deploy tests for released builds

### DIFF
--- a/suites/ceph-deploy-release/distros
+++ b/suites/ceph-deploy-release/distros
@@ -1,0 +1,1 @@
+../../distros/supported/

--- a/suites/ceph-deploy-release/overrides/ceph_deploy_dmcrypt.yaml
+++ b/suites/ceph-deploy-release/overrides/ceph_deploy_dmcrypt.yaml
@@ -1,0 +1,3 @@
+overrides:
+   ceph-deploy:
+      dmcrypt: yes

--- a/suites/ceph-deploy-release/overrides/disable_diff_journal_disk.yaml
+++ b/suites/ceph-deploy-release/overrides/disable_diff_journal_disk.yaml
@@ -1,0 +1,3 @@
+overrides:
+   ceph-deploy:
+      separate_journal_disk:

--- a/suites/ceph-deploy-release/tasks/release-install-test.yaml
+++ b/suites/ceph-deploy-release/tasks/release-install-test.yaml
@@ -1,0 +1,40 @@
+overrides:
+  ceph-deploy:
+    branch:
+      stable: jewel
+    conf:
+      global:
+        mon pg warn min per osd: 2
+        osd pool default size: 2
+roles:
+- - mon.a
+  - mds.0
+  - osd.0
+  - osd.1
+  - osd.2
+- - osd.3
+  - osd.4
+  - osd.5
+  - mon.b
+- - client.0
+openstack:
+  - machine:
+      disk: 10 # GB
+      ram: 2000 # MB
+      cpus: 1
+    volumes: # attached to each instance
+      count: 3
+      size: 10 # GB
+tasks:
+- ssh_keys:
+- ceph-deploy:
+- workunit:
+    clients:
+      client.0:
+      - rados/test.sh
+- workunit:
+    clients:
+      client.0:
+        - rbd/test_librbd_python.sh
+    env:
+      RBD_FEATURES: "1"


### PR DESCRIPTION
simple test suite to test ceph from download.ceph.com (with stable: jewel flag)

@alfredodeza  @ktdreyer ping

http://pulpito.ceph.com/vasu-2016-09-21_20:31:36-ceph-deploy-release-jewel---basic-vps/ ,

Fixed one config issue in this run
http://pulpito.ceph.com/vasu-2016-09-21_21:14:05-ceph-deploy-release-jewel---basic-vps/ 

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>