### PR TITLE
jewel: suites/rbd: remove helgrind test cases

### DIFF
--- a/suites/rbd/valgrind/validator/helgrind.yaml
+++ b/suites/rbd/valgrind/validator/helgrind.yaml
@@ -1,9 +1,0 @@
-overrides:
-  install:
-    ceph:
-      debuginfo: true
-  rbd_fsx:
-    valgrind: ["--tool=helgrind"]
-  workunit:
-    env:
-      VALGRIND: "helgrind"


### PR DESCRIPTION
Helgrind cannot properly handle Ceph's use of std::mutex --
resulting in numerous false positives and potential assertion
failures.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>
(cherry picked from commit b29bf9253d7d2201f4cf01b0fd6997ed1bae231f)