### PR TITLE
fs: enable ceph-fuse permission checking for all pjd suites

### DIFF
--- a/suites/fs/32bits/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/suites/fs/32bits/tasks/cfuse_workunit_suites_pjd.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        fuse set user groups: true
+        fuse default permissions: false
 tasks:
 - workunit:
     clients:

--- a/suites/fs/basic/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/suites/fs/basic/tasks/cfuse_workunit_suites_pjd.yaml
@@ -4,6 +4,8 @@ overrides:
       client:
         debug ms: 1
         debug client: 20
+        fuse set user groups: true
+        fuse default permissions: false
       mds:
         debug ms: 1
         debug mds: 20

--- a/suites/fs/permission/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/suites/fs/permission/tasks/cfuse_workunit_suites_pjd.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        fuse set user groups: true
+        fuse default permissions: false
 tasks:
 - workunit:
     clients:

--- a/suites/fs/thrash/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/suites/fs/thrash/tasks/cfuse_workunit_suites_pjd.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        fuse set user groups: true
+        fuse default permissions: false
 tasks:
 - ceph-fuse:
 - workunit:

--- a/suites/marginal/multimds/tasks/workunit_suites_pjd.yaml
+++ b/suites/marginal/multimds/tasks/workunit_suites_pjd.yaml
@@ -2,7 +2,8 @@ overrides:
   ceph:
     conf:
       client:
-        fuse_default_permissions: 1
+        fuse default permissions: false
+        fuse set user groups: true
 tasks:
 - workunit:
     clients:

--- a/suites/multimds/basic/tasks/suites_pjd.yaml
+++ b/suites/multimds/basic/tasks/suites_pjd.yaml
@@ -4,6 +4,8 @@ overrides:
       client:
         debug ms: 1
         debug client: 20
+        fuse set user groups: true
+        fuse default permissions: false
       mds:
         debug ms: 1
         debug mds: 20

--- a/suites/powercycle/osd/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/suites/powercycle/osd/tasks/cfuse_workunit_suites_pjd.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        fuse default permissions: false
+        fuse set user groups: true
 tasks:
 - ceph-fuse:
 - workunit:

--- a/suites/smoke/basic/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/suites/smoke/basic/tasks/cfuse_workunit_suites_pjd.yaml
@@ -9,6 +9,8 @@ tasks:
       client:
         debug client: 20
         debug ms: 1
+        fuse default permissions: false
+        fuse set user groups: true
 - ceph-fuse:
 - workunit:
     clients:


### PR DESCRIPTION
As we improve our security model, we need to test it instead of the kernel.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>