### PR TITLE
tasks/dump_stuck: fix failure

### DIFF
--- a/tasks/dump_stuck.py
+++ b/tasks/dump_stuck.py
@@ -123,7 +123,7 @@ def task(ctx, config):
             check_stuck(
                 manager,
                 num_inactive=0,
-                num_unclean=0,
+                num_unclean=num_pgs,
                 num_stale=num_pgs,
                 )
             done = True

--- a/tasks/dump_stuck.py
+++ b/tasks/dump_stuck.py
@@ -24,10 +24,15 @@ def check_stuck(manager, num_inactive, num_unclean, num_stale, timeout=10):
     :param timeout: timeout value for get_stuck_pgs calls
     """
     inactive = manager.get_stuck_pgs('inactive', timeout)
-    assert len(inactive) == num_inactive
     unclean = manager.get_stuck_pgs('unclean', timeout)
-    assert len(unclean) == num_unclean
     stale = manager.get_stuck_pgs('stale', timeout)
+    log.info('hi mom')
+    log.info('inactive %s / %d,  unclean %s / %d,  stale %s / %d',
+             len(inactive), num_inactive,
+             len(unclean), num_unclean,
+             len(stale), num_stale)
+    assert len(inactive) == num_inactive
+    assert len(unclean) == num_unclean
     assert len(stale) == num_stale
 
     # check health output as well
@@ -105,10 +110,12 @@ def task(ctx, config):
         num_stale=0,
         )
 
+    log.info('stopping both osds')
     for id_ in teuthology.all_roles_of_type(ctx.cluster, 'osd'):
         manager.kill_osd(id_)
         manager.mark_down_osd(id_)
 
+    log.info('waiting for all to be stale')
     starttime = time.time()
     done = False
     while not done:
@@ -125,6 +132,7 @@ def task(ctx, config):
             if time.time() - starttime > 900:
                 raise
 
+    log.info('reviving')
     for id_ in teuthology.all_roles_of_type(ctx.cluster, 'osd'):
         manager.revive_osd(id_)
         manager.mark_in_osd(id_)


### PR DESCRIPTION
There seem to be two problems: one is that the mon's 'pg dump_stuck ...' result
isn't coherent with the health warning.  This is fixed by a ceph commit in
https://github.com/ceph/ceph/pull/11339.  The other is that this test
didn't account for the fact that when the OSDs went down the PGs would also
appear unclean because they OSDs may not fail simultaneously.  That used
to be a hard case to trigger, but with the RST markdown it happens in the
normal case. We adjust this test so that it reliably happens and then
also assert that PGs are unclean.