### PR TITLE
do not whitelist "failed to encode"

### DIFF
--- a/suites/upgrade/hammer/newer/0-cluster/start.yaml
+++ b/suites/upgrade/hammer/newer/0-cluster/start.yaml
@@ -4,7 +4,6 @@ overrides:
     - scrub
     - scrub mismatch
     - ScrubResult
-    - failed to encode
     - soft lockup
     - detected stalls on CPUs
     fs: xfs

--- a/suites/upgrade/hammer/newer/4-final/osdthrash.yaml
+++ b/suites/upgrade/hammer/newer/4-final/osdthrash.yaml
@@ -4,7 +4,6 @@ overrides:
     - wrongly marked me down
     - objects unfound and apparently lost
     - log bound mismatch
-    - failed to encode
 tasks:
 - sequential:
   - thrashosds:

--- a/suites/upgrade/hammer/older/0-cluster/start.yaml
+++ b/suites/upgrade/hammer/older/0-cluster/start.yaml
@@ -4,7 +4,6 @@ overrides:
     - scrub
     - scrub mismatch
     - ScrubResult
-    - failed to encode
     - soft lockup
     - detected stalls on CPUs
     fs: xfs

--- a/suites/upgrade/hammer/older/4-final/osdthrash.yaml
+++ b/suites/upgrade/hammer/older/4-final/osdthrash.yaml
@@ -4,7 +4,6 @@ overrides:
     - wrongly marked me down
     - objects unfound and apparently lost
     - log bound mismatch
-    - failed to encode
 tasks:
 - sequential:
   - thrashosds:


### PR DESCRIPTION
newer hammer (0.94.6+) with CRC check will print
 cluster [WRN] failed to encode map e2314 with expected crc"
if CRC does not match. but this should not happen if the peer re-encode
the incrementals without CRC fields if we are upgrading from 0.94.6
to a newer hammer version with the fix of tracker#17386.

Fixes: http://tracker.ceph.com/issues/17386
Signed-off-by: Kefu Chai <kchai@redhat.com>