### PR TITLE
rados: move readwrite test out of thrash matrix

### DIFF
--- a/suites/rados/basic/tasks/readwrite.yaml
+++ b/suites/rados/basic/tasks/readwrite.yaml
@@ -5,6 +5,8 @@ overrides:
       osd:
         osd_discard_disconnected_ops: false
 tasks:
+- install:
+- ceph:
 - rados:
     clients: [client.0]
     ops: 4000


### PR DESCRIPTION
The thrash matrix includes min_size = 2 and size = 2.  This
is fine and good, except that the inevitable slow rados ops
that generates make readwrite.yaml issue timeouts and
fail.  Since the workload isn't meant to tolerate slow
requests, move it into the basic/ group.

Signed-off-by: Sage Weil <sage@redhat.com>