### PR TITLE
rados/singleton/all/osd-recovery*: disable fast fail

### DIFF
--- a/suites/rados/singleton/all/osd-recovery-incomplete.yaml
+++ b/suites/rados/singleton/all/osd-recovery-incomplete.yaml
@@ -18,4 +18,5 @@ tasks:
     conf:
       osd:
         osd min pg log entries: 5
+        osd_fast_fail_on_connection_refused: false
 - osd_recovery.test_incomplete_pgs:

--- a/suites/rados/singleton/all/osd-recovery.yaml
+++ b/suites/rados/singleton/all/osd-recovery.yaml
@@ -17,4 +17,5 @@ tasks:
     conf:
       osd:
         osd min pg log entries: 5
+        osd_fast_fail_on_connection_refused: false
 - osd_recovery:


### PR DESCRIPTION
This test relies on being able to kill two OSDs before
they detect the failures on their own.

Signed-off-by: Sage Weil <sage@redhat.com>