### PR TITLE
assert based on inconsistent objects count instead of all keys

### DIFF
--- a/tasks/scrub_test.py
+++ b/tasks/scrub_test.py
@@ -325,10 +325,10 @@ def test_list_inconsistent_obj(ctx, manager, osd_remote, pg, acting, osd_id,
             with contextlib.closing(StringIO()) as out:
                 mon.run(args=cmd.split(), stdout=out)
                 objs = json.loads(out.getvalue())
-            assert len(objs) == 1
+            assert len(objs['inconsistents']) == 1
 
             checker = InconsistentObjChecker(osd_id, acting, obj_name)
-            inc_obj = objs[0]
+            inc_obj = objs['inconsistents'][0]
             log.info('inc = %r', inc_obj)
             checker.basic_checks(inc_obj)
             for check in checks:


### PR DESCRIPTION
epoch keys also exist in the objs dump, count only
inconsistent objects

Signed-off-by: Vasu Kulkarni vasu@redhat.com
