### PR TITLE
Added short pg log entries to rgw test

### DIFF
--- a/suites/rgw/verify/tasks/rgw_s3tests.yaml
+++ b/suites/rgw/verify/tasks/rgw_s3tests.yaml
@@ -13,5 +13,8 @@ tasks:
 overrides:
   ceph:
     conf:
+      global:
+        osd_min_pg_log_entries: 10
+        osd_max_pg_log_entries: 10
       client:
         rgw lc debug interval: 10


### PR DESCRIPTION
This change aims to test rgw with messenger failure injection
and very short logs.

Signed-off-by: Tamil Muthamizhan <tmuthami@redhat.com>