### PR TITLE
rados/upgrade: skip ceph-mgr on jewel install

### DIFF
--- a/suites/rados/upgrade/jewel-x-singleton/1-jewel-install/jewel.yaml
+++ b/suites/rados/upgrade/jewel-x-singleton/1-jewel-install/jewel.yaml
@@ -3,6 +3,7 @@ meta:
 tasks:
 - install:
     branch: jewel
+    exclude_packages: ['ceph-mgr']
 - print: "**** done install jewel"
 - ceph:
 - print: "**** done ceph"


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>