### PR TITLE
rados/singleton: need 3 osds for radostool test

### DIFF
--- a/suites/rados/singleton/all/radostool.yaml
+++ b/suites/rados/singleton/all/radostool.yaml
@@ -2,6 +2,7 @@ roles:
 - - mon.a
   - osd.0
   - osd.1
+  - osd.2
   - client.0
 openstack:
   - volumes: # attached to each instance


### PR DESCRIPTION
There's a k=2 m=1 ec pool in the test!

Fixes: http://tracker.ceph.com/issues/17775
Signed-off-by: Sage Weil <sage@redhat.com>