### PR TITLE
packages: s/libcephfs2-devel/libcephfs-devel/

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -41,7 +41,7 @@ ceph:
   - cephfs-java
   - libcephfs_jni1
   - libcephfs2
-  - libcephfs2-devel
+  - libcephfs-devel
   - librados2
   - librbd1
   - python-ceph


### PR DESCRIPTION
fixes http://pulpito.ceph.com/kchai-2016-11-11_07:45:56-rados-wip-kefu-testing---basic-smithi/539297/
```
2016-11-11T08:00:59.253 DEBUG:teuthology.task.install:Excluding packages: ['ceph-mgr', 'libcephfs2']
2016-11-11T08:00:59.253 DEBUG:teuthology.task.install:Package list is: {'deb': ['ceph-mds', 'rbd-fuse', 'librbd1', 'ceph-fuse', 'python-ceph', 'ceph-common', 'libcephfs-java', 'ceph', 'libcephfs-dev', 'ceph-test', 'radosgw', 'librados2', 'libcephfs-jni'], 'rpm': ['libcephfs_jni1', 'rbd-fuse', 'ceph-radosgw', 'librbd1', 'ceph-fuse', 'python-ceph', 'ceph', 'ceph-test', 'librados2', 'cephfs-java', 'libcephfs2-devel']}
...
2016-11-11T08:08:12.729 INFO:teuthology.orchestra.run.smithi095:Running: "sudo yum -y install '' libcephfs2-devel"
2016-11-11T08:08:12.990 INFO:teuthology.orchestra.run.smithi095.stdout:Loaded plugins: fastestmirror, langpacks, priorities
2016-11-11T08:08:13.025 INFO:teuthology.orchestra.run.smithi095.stdout:Loading mirror speeds from cached hostfile
2016-11-11T08:08:13.026 INFO:teuthology.orchestra.run.smithi095.stdout: * base: mirrors.advancedhosters.com
2016-11-11T08:08:13.027 INFO:teuthology.orchestra.run.smithi095.stdout: * epel: ftp.linux.ncsu.edu
2016-11-11T08:08:13.027 INFO:teuthology.orchestra.run.smithi095.stdout: * extras: mirror.es.its.nyu.edu
2016-11-11T08:08:13.027 INFO:teuthology.orchestra.run.smithi095.stdout: * updates: mirror.us.leaseweb.net
2016-11-11T08:08:13.784 INFO:teuthology.orchestra.run.smithi095.stdout:24 packages excluded due to repository priority protections
2016-11-11T08:08:13.986 INFO:teuthology.orchestra.run.smithi095.stdout:No package  available.
2016-11-11T08:08:14.399 INFO:teuthology.orchestra.run.smithi095.stdout:No package libcephfs2-devel available.
```

see http://qa-proxy.ceph.com/teuthology/kchai-2016-11-11_07:45:56-rados-wip-kefu-testing---basic-smithi/539297/teuthology.log


i know, "libcephfs2-devel" also works as long as we use the ceph branch including the libcephfs renaming. but 1) "libcephfs-devel" is more correct than "libcephfs2-devel" in the context of testing master branch of "ceph", because we always test the latest libcephfs-devel, 2) this is consistent with the "deb" section in the same file.