### PR TITLE
upgrade/hammer-x/stress-split: set require_jewel_osds

### DIFF
--- a/suites/upgrade/hammer-x/stress-split/8-next-mon/monc.yaml
+++ b/suites/upgrade/hammer-x/stress-split/8-next-mon/monc.yaml
@@ -5,4 +5,8 @@ tasks:
     wait-for-osds-up: true
 - print: "**** done ceph.restart mon.c 8-next-mon"
 - ceph.wait_for_mon_quorum: [a, b, c]
+- exec:
+    osd.0:
+      - sleep 300 # http://tracker.ceph.com/issues/17808
+      - ceph osd set require_jewel_osds
 - print: "**** done wait_for_mon_quorum 8-next-mon"


### PR DESCRIPTION
It was missing and the cluster permanently stays on WARNING state after
the upgrade of the OSDs.

Signed-off-by: Loic Dachary <loic@dachary.org>