### PR TITLE
tasks.ceph_deploy: Work around admin keyring bug

### DIFF
--- a/tasks/ceph_deploy.py
+++ b/tasks/ceph_deploy.py
@@ -322,6 +322,13 @@ def build_ceph_cluster(ctx, config):
         node_dev_list = get_dev_for_osd(ctx, config)
         for d in node_dev_list:
             node = d[0]
+            # Start work around for http://tracker.ceph.com/issues/17849
+            if config.get('dmcrypt') is not None:
+                admin = './ceph-deploy admin ' + node
+                estatus = execute_ceph_deploy(admin)
+                if estatus != 0:
+                    raise RuntimeError("ceph-deploy: Failed to give admin role to osd node")
+            # End work around for http://tracker.ceph.com/issues/17849
             for disk in d[1:]:
                 zap = './ceph-deploy disk zap ' + node + ':' + disk
                 estatus = execute_ceph_deploy(zap)


### PR DESCRIPTION
This is a short term work around for bug:

    http://tracker.ceph.com/issues/17849

As requested by Sage on the ceph-devel mailing list in thread:

    "Understanding encrypted OSD's and cephx"

The work around adds the admin key to all nodes with encrypted OSD's by
running the command:

    ceph-deploy admin $NODE

So the admin keyring is present.

This work around should be fixed by making a new "one step set up" command,
as detailed by Sage.

Signed-off-by: Owen Synge <osynge@suse.com>