### PR TITLE
tasks.rgw: 'time' imported but unused

### DIFF
--- a/tasks/rgw.py
+++ b/tasks/rgw.py
@@ -6,7 +6,6 @@ import contextlib
 import json
 import logging
 import os
-import time
 import errno
 import util.rgw as rgw_utils
 


### PR DESCRIPTION
flake8 was failing.

Signed-off-by: Owen Synge <osynge@suse.com>