### PR TITLE
jewel: rgw: fix some races with radosgw and radosgw-agent startup

### DIFF
--- a/suites/rgw/singleton/all/radosgw-admin-data-sync.yaml
+++ b/suites/rgw/singleton/all/radosgw-admin-data-sync.yaml
@@ -50,8 +50,6 @@ tasks:
         name: client1-system-user
         access key: 1te6NH5mcdcq0Tc5i8i3
         secret key: Py4IOauQoL18Gp2zM7lC1vLmoawgqcYPbYGcWfXw
-- sleep:
-    duration: 15
 - radosgw-agent:
     client.0:
       max-entries: 10

--- a/suites/rgw/singleton/all/radosgw-admin-multi-region.yaml
+++ b/suites/rgw/singleton/all/radosgw-admin-multi-region.yaml
@@ -55,8 +55,6 @@ tasks:
         name: client1-system-user
         access key: 1te6NH5mcdcq0Tc5i8i3
         secret key: Py4IOauQoL18Gp2zM7lC1vLmoawgqcYPbYGcWfXw
-- sleep:
-    duration: 5
 - radosgw-agent:
     client.0:
       src: client.0

--- a/suites/rgw/verify/tasks/rgw_s3tests_multiregion.yaml
+++ b/suites/rgw/verify/tasks/rgw_s3tests_multiregion.yaml
@@ -51,8 +51,6 @@ tasks:
         name: client1-system-user
         access key: 0te6NH5mcdcq0Tc5i8i2
         secret key: Oy4IOauQoL18Gp2zM7lC1vLmoawgqcYPbYGcWfXv
-- sleep:
-    duration: 5
 - radosgw-agent:
     client.0:
       src: client.0

--- a/tasks/rgw.py
+++ b/tasks/rgw.py
@@ -1033,12 +1033,6 @@ def pull_configuration(ctx, config, regions, role_endpoints, realm, master_clien
     yield
 
 @contextlib.contextmanager
-def wait_for_master():
-    log.debug("wait_for_master")
-    time.sleep(20)
-    yield
-
-@contextlib.contextmanager
 def task(ctx, config):
     """
     Either use configure apache to run a rados gateway, or use the built-in
@@ -1296,7 +1290,6 @@ def task(ctx, config):
         else:
             raise ValueError("frontend must be 'apache' or 'civetweb'")
 
-        subtasks.extend([lambda: wait_for_master(),])
         subtasks.extend([
             lambda: pull_configuration(ctx=ctx,
                                        config=config,

--- a/tasks/rgw.py
+++ b/tasks/rgw.py
@@ -6,7 +6,6 @@ import contextlib
 import json
 import logging
 import os
-import time
 import errno
 import util.rgw as rgw_utils
 


### PR DESCRIPTION
(jewel backport of https://github.com/ceph/ceph-qa-suite/pull/1269)

Startup races are the root cause of several failures in the rgw suite. Teuthology's daemon framework doesn't allow us to block until the daemon finishes startup, so we've added sleeps to account for this. But there are cases where `radosgw` and `radosgw-agent` instances take over a minute to start, so the sleeps of 5-20 seconds are insufficient (and raising their durations would be wasteful in most cases).

This PR replaces these sleeps with http requests that poll the daemon with retry/backoff until it starts accepting connections. For `radosgw`, this happens at the end of `start_rgw()`. For `radosgw-agent`, it just adds retry/backoff to the http requests we're already sending.

Fixes: http://tracker.ceph.com/issues/16129
Fixes: http://tracker.ceph.com/issues/17794
Fixes: http://tracker.ceph.com/issues/17872