### PR TITLE
upgrade/hammer-x: do not whitelist 'failed to encode map'

### DIFF
--- a/suites/upgrade/hammer-x/parallel/0-cluster/start.yaml
+++ b/suites/upgrade/hammer-x/parallel/0-cluster/start.yaml
@@ -19,7 +19,6 @@ overrides:
     - wrongly marked me down
     - soft lockup
     - detected stalls on CPUs
-    - failed to encode map
     conf:
       mon:
         mon warn on legacy crush tunables: false

--- a/suites/upgrade/hammer-x/parallel/3-upgrade-sequence/upgrade-osd-mds-mon.yaml
+++ b/suites/upgrade/hammer-x/parallel/3-upgrade-sequence/upgrade-osd-mds-mon.yaml
@@ -6,8 +6,13 @@ upgrade-sequence:
    - sleep:
        duration: 60
    - ceph.restart:
-       daemons: [mon.a]
+       daemons: [osd.2, osd.3]
        wait-for-healthy: true
+   - sleep:
+       duration: 60
+   - ceph.restart:
+       daemons: [mon.a]
+       wait-for-healthy: false
    - sleep:
        duration: 60
    - ceph.restart: [mds.a]
@@ -20,12 +25,10 @@ upgrade-sequence:
         - sudo ceph osd crush tunables hammer
    - print: "**** done ceph osd crush tunables hammer"
    - ceph.restart:
-       daemons: [osd.2, osd.3]
-   - sleep:
-       duration: 60
-   - ceph.restart:
        daemons: [mon.b, mon.c]
        wait-for-healthy: false
+   - sleep:
+       duration: 30
    - exec:
        osd.0:
          - sleep 300 # http://tracker.ceph.com/issues/17808

--- a/suites/upgrade/hammer-x/v0-94-4-stop/ignore.yaml
+++ b/suites/upgrade/hammer-x/v0-94-4-stop/ignore.yaml
@@ -3,7 +3,6 @@ overrides:
     log-whitelist:
     - scrub mismatch
     - ScrubResult
-    - failed to encode map
     conf:
       mon:
         mon warn on legacy crush tunables: false


### PR DESCRIPTION
We should avoid these messages now.

Signed-off-by: Sage Weil <sage@redhat.com>