### PR TITLE
suites/knfs: pin to ubuntu

### DIFF
--- a/suites/knfs/basic/ceph/base.yaml
+++ b/suites/knfs/basic/ceph/base.yaml
@@ -1,3 +1,6 @@
+
+os_type: ubuntu
+
 overrides:
   ceph:
     conf:


### PR DESCRIPTION
Workaround for http://tracker.ceph.com/issues/16397, which
manifests when we run bleeding edge kernels against the version
of nfs-utils in centos7.

Signed-off-by: John Spray <john.spray@redhat.com>