### PR TITLE
rados/thrash*: do no set osd_max_backfills=1

### DIFF
--- a/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
+++ b/suites/rados/thrash-erasure-code-big/thrashers/default.yaml
@@ -8,9 +8,9 @@ tasks:
     conf:
       osd:
         osd debug reject backfill probability: .3
-        osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 6
 - thrashosds:
     timeout: 1200
     chance_pgnum_grow: 1

--- a/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
+++ b/suites/rados/thrash-erasure-code-big/thrashers/fastread.yaml
@@ -9,9 +9,9 @@ tasks:
         mon osd pool ec fast read: 1
       osd:
         osd debug reject backfill probability: .3
-        osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 2
 - thrashosds:
     timeout: 1200
     chance_pgnum_grow: 1

--- a/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
+++ b/suites/rados/thrash-erasure-code-big/thrashers/morepggrow.yaml
@@ -3,9 +3,9 @@ tasks:
 - ceph:
     conf:
       osd:
-        osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 9
     log-whitelist:
     - wrongly marked me down
     - objects unfound and apparently lost

--- a/suites/rados/thrash-erasure-code-shec/thrashers/default.yaml
+++ b/suites/rados/thrash-erasure-code-shec/thrashers/default.yaml
@@ -8,9 +8,9 @@ tasks:
     conf:
       osd:
         osd debug reject backfill probability: .3
-        osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 3
 - thrashosds:
     timeout: 1200
     chance_pgnum_grow: 1

--- a/suites/rados/thrash-erasure-code/thrashers/default.yaml
+++ b/suites/rados/thrash-erasure-code/thrashers/default.yaml
@@ -7,9 +7,9 @@ tasks:
     conf:
       osd:
         osd debug reject backfill probability: .3
-        osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 2
 - thrashosds:
     timeout: 1200
     chance_pgnum_grow: 1

--- a/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
+++ b/suites/rados/thrash-erasure-code/thrashers/fastread.yaml
@@ -9,9 +9,9 @@ tasks:
         mon osd pool ec fast read: 1
       osd:
         osd debug reject backfill probability: .3
-        osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 3
 - thrashosds:
     timeout: 1200
     chance_pgnum_grow: 1

--- a/suites/rados/thrash-erasure-code/thrashers/mapgap.yaml
+++ b/suites/rados/thrash-erasure-code/thrashers/mapgap.yaml
@@ -7,6 +7,7 @@ overrides:
         osd map cache size: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 5
 tasks:
 - install:
 - ceph:

--- a/suites/rados/thrash-erasure-code/thrashers/morepggrow.yaml
+++ b/suites/rados/thrash-erasure-code/thrashers/morepggrow.yaml
@@ -3,9 +3,9 @@ tasks:
 - ceph:
     conf:
       osd:
-        osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 9
     log-whitelist:
     - wrongly marked me down
     - objects unfound and apparently lost

--- a/suites/rados/thrash-erasure-code/thrashers/pggrow.yaml
+++ b/suites/rados/thrash-erasure-code/thrashers/pggrow.yaml
@@ -8,6 +8,7 @@ tasks:
       osd:
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 4
 - thrashosds:
     timeout: 1200
     chance_pgnum_grow: 2

--- a/suites/rados/thrash/thrashers/default.yaml
+++ b/suites/rados/thrash/thrashers/default.yaml
@@ -7,9 +7,9 @@ tasks:
     conf:
       osd:
         osd debug reject backfill probability: .3
-        osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 3
 - thrashosds:
     timeout: 1200
     chance_pgnum_grow: 1

--- a/suites/rados/thrash/thrashers/mapgap.yaml
+++ b/suites/rados/thrash/thrashers/mapgap.yaml
@@ -8,6 +8,7 @@ overrides:
         osd scrub min interval: 60
         osd scrub max interval: 120
         osd scrub during recovery: false
+        osd max backfills: 6
 tasks:
 - install:
 - ceph:

--- a/suites/rados/thrash/thrashers/morepggrow.yaml
+++ b/suites/rados/thrash/thrashers/morepggrow.yaml
@@ -3,13 +3,13 @@ tasks:
 - ceph:
     conf:
       osd:
-        osd max backfills: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
         journal throttle high multiple: 2
         journal throttle max multiple: 10
         filestore queue throttle high multiple: 2
         filestore queue throttle max multiple: 10
+        osd max backfills: 9
     log-whitelist:
     - wrongly marked me down
     - objects unfound and apparently lost

--- a/suites/rados/thrash/thrashers/pggrow.yaml
+++ b/suites/rados/thrash/thrashers/pggrow.yaml
@@ -9,6 +9,7 @@ tasks:
         osd scrub min interval: 60
         osd scrub max interval: 120
         filestore odsync write: true
+        osd max backfills: 2
 - thrashosds:
     timeout: 1200
     chance_pgnum_grow: 2


### PR DESCRIPTION
This can lead to a copy-from vs backfill deadlock; see
http://tracker.ceph.com/issues/18085

This effectively reverts 5e880228fd7f59063d22a51eb5488b369b0c8360
which aimed to catch bugs in recovery reservations.

Signed-off-by: Sage Weil <sage@redhat.com>