### PR TITLE
upgrade: ceph-test is needed for ceph-coverage

### DIFF
--- a/suites/upgrade/client-upgrade/hammer-client-x/rbd/1-install/hammer-client-x.yaml
+++ b/suites/upgrade/client-upgrade/hammer-client-x/rbd/1-install/hammer-client-x.yaml
@@ -4,7 +4,7 @@ tasks:
     exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev']
 - print: "**** done install hammer"
 - install.upgrade:
-   exclude_packages: ['ceph-test', 'ceph-test-dbg']
+   exclude_packages: ['ceph-test-dbg']
    client.1:
 - print: "**** done install.upgrade client.1"
 - ceph:


### PR DESCRIPTION
Do not exclude the ceph-test package otherwise the ceph-coverage
executable is not installed.

Fixes: http://tracker.ceph.com/issues/16506

Signed-off-by: Loic Dachary <loic@dachary.org>