### PR TITLE
krbd/unmap: pre-single-major is now 3.12.z

### DIFF
--- a/suites/krbd/unmap/kernels/pre-single-major.yaml
+++ b/suites/krbd/unmap/kernels/pre-single-major.yaml
@@ -1,7 +1,7 @@
 overrides:
   kernel:
     client.0:
-      branch: nightly_pre-single-major # nightly/pre-single-major, v3.13
+      branch: nightly_pre-single-major # v3.12.z
 tasks:
 - exec:
     client.0:


### PR DESCRIPTION
3.13 won't build on newer distros, due to lack of gcc5 support.
nightly/pre-single-major (with a slash) is now gone.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>