### PR TITLE
do all valgrind runs on centos

### DIFF
--- a/suites/fs/verify/validater/valgrind.yaml
+++ b/suites/fs/verify/validater/valgrind.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/suites/multimds/verify/validater/valgrind.yaml
+++ b/suites/multimds/verify/validater/valgrind.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
+++ b/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/suites/rados/verify/validater/valgrind.yaml
+++ b/suites/rados/verify/validater/valgrind.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/suites/rbd/valgrind/validator/memcheck.yaml
+++ b/suites/rbd/valgrind/validator/memcheck.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/suites/rgw/verify/tasks/rgw_s3tests.yaml
+++ b/suites/rgw/verify/tasks/rgw_s3tests.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 tasks:
 - install:
     flavor: notcmalloc

--- a/suites/rgw/verify/tasks/rgw_s3tests_multiregion.yaml
+++ b/suites/rgw/verify/tasks/rgw_s3tests_multiregion.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 tasks:
 - install:
     flavor: notcmalloc

--- a/suites/rgw/verify/tasks/rgw_swift.yaml
+++ b/suites/rgw/verify/tasks/rgw_swift.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 tasks:
 - install:
     flavor: notcmalloc

--- a/suites/rgw/verify/validater/valgrind.yaml
+++ b/suites/rgw/verify/validater/valgrind.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:


### PR DESCRIPTION
The xenial valgrind has a bug with generating random
numbers; see http://tracker.ceph.com/issues/18126

Revert this when it is fixed.

Signed-off-by: Sage Weil <sage@redhat.com>