### PR TITLE
tasks/ceph: restore context of osd mount path before mkfs

### DIFF
--- a/tasks/ceph.py
+++ b/tasks/ceph.py
@@ -752,6 +752,12 @@ def cluster(ctx, config):
                         mnt_point,
                     ]
                 )
+                remote.run(
+                    args=[
+                        'sudo', '/sbin/restorecon', mnt_point,
+                    ],
+                    check_status=False,
+                )
                 if not remote in ctx.disk_config.remote_to_roles_to_dev_mount_options:
                     ctx.disk_config.remote_to_roles_to_dev_mount_options[remote] = {}
                 ctx.disk_config.remote_to_roles_to_dev_mount_options[remote][role] = mount_options


### PR DESCRIPTION
all newly created files and directories under the mount dir inherit the
SELinux type of their parent directory. so we need to set it before
mkfs.

Fixes: http://tracker.ceph.com/issues/16800
Signed-off-by: Kefu Chai <kchai@redhat.com>