### PR TITLE
tasks/cephfs: mds_revoke_cap_timeout to mds_session_timeout

### DIFF
--- a/tasks/cephfs/test_client_limits.py
+++ b/tasks/cephfs/test_client_limits.py
@@ -120,10 +120,10 @@ class TestClientLimits(CephFSTestCase):
         # Client B tries to stat the file that client A created
         rproc = self.mount_b.write_background("file1")
 
-        # After mds_revoke_cap_timeout, we should see a health warning (extra lag from
+        # After mds_session_timeout, we should see a health warning (extra lag from
         # MDS beacon period)
-        mds_revoke_cap_timeout = int(self.fs.get_config("mds_revoke_cap_timeout"))
-        self.wait_for_health("failing to respond to capability release", mds_revoke_cap_timeout + 10)
+        mds_session_timeout = int(self.fs.get_config("mds_session_timeout"))
+        self.wait_for_health("failing to respond to capability release", mds_session_timeout + 10)
 
         # Client B should still be stuck
         self.assertFalse(rproc.finished)


### PR DESCRIPTION
mds_revoke_cap_timeout is being folded into the mds_session_timeout.
Switch to using the mds_session_timeout in the QA tests.

Signed-off-by: Jeff Layton <jlayton@redhat.com>